### PR TITLE
feat(cli): M0.3 CLI Connects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,21 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# WebSocket
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
+url = "2"
+
+# TUI
+ratatui = "0.29"
+crossterm = "0.28"
+
+# HTTP client (CLI health check)
+reqwest = { version = "0.12", features = ["json"] }
+
 # Internal crates
 gyre-common = { path = "crates/gyre-common" }
 gyre-ports = { path = "crates/gyre-ports" }

--- a/crates/gyre-cli/Cargo.toml
+++ b/crates/gyre-cli/Cargo.toml
@@ -17,3 +17,14 @@ tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 gyre-common = { workspace = true }
+clap = { workspace = true }
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }
+url = { workspace = true }
+ratatui = { workspace = true }
+crossterm = { workspace = true }
+reqwest = { workspace = true }
+
+[dev-dependencies]
+tokio-test = "0.4"
+serde_json = { workspace = true }

--- a/crates/gyre-cli/src/main.rs
+++ b/crates/gyre-cli/src/main.rs
@@ -1,19 +1,176 @@
+mod tui;
+mod ws;
+
 use anyhow::Result;
+use clap::{Parser, Subcommand};
+use futures_util::StreamExt;
+use gyre_common::WsMessage;
+use tokio_tungstenite::tungstenite::Message;
 use tracing::info;
+
+const DEFAULT_SERVER: &str = "ws://localhost:3000/ws";
+const DEFAULT_TOKEN: &str = "gyre-dev-token";
+
+#[derive(Parser)]
+#[command(name = "gyre", about = "Gyre platform CLI", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Connect to the Gyre server and stay connected
+    Connect {
+        #[arg(long, default_value = DEFAULT_SERVER)]
+        server: String,
+        #[arg(long, default_value = DEFAULT_TOKEN)]
+        token: String,
+    },
+    /// Send a ping and print the round-trip time
+    Ping {
+        #[arg(long, default_value = DEFAULT_SERVER)]
+        server: String,
+        #[arg(long, default_value = DEFAULT_TOKEN)]
+        token: String,
+    },
+    /// Check server health via HTTP
+    Health {
+        #[arg(long, default_value = "http://localhost:3000")]
+        server: String,
+    },
+    /// Launch the TUI dashboard
+    Tui {
+        #[arg(long, default_value = DEFAULT_SERVER)]
+        server: String,
+        #[arg(long, default_value = DEFAULT_TOKEN)]
+        token: String,
+    },
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
         )
         .init();
 
-    info!("gyre CLI starting");
+    let cli = Cli::parse();
 
-    // TODO(m0.3): wire up clap commands, WebSocket connection to server, TUI
-    // See: specs/milestones/m0-walking-skeleton.md - Deliverable 3: CLI Connects
+    match cli.command {
+        Commands::Connect { server, token } => {
+            info!("Connecting to {server}");
+            let client = ws::WsClient::new(server.clone(), token);
+            let mut ws = client.connect_and_auth().await?;
+            println!("Connected to {server}. Listening for messages (Ctrl-C to quit)...");
+            while let Some(frame) = ws.next().await {
+                match frame? {
+                    Message::Text(text) => {
+                        let msg: Result<WsMessage, _> = serde_json::from_str(&text);
+                        match msg {
+                            Ok(m) => println!("{m:?}"),
+                            Err(_) => println!("Raw: {text}"),
+                        }
+                    }
+                    Message::Close(_) => {
+                        println!("Server closed connection");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Commands::Ping { server, token } => {
+            info!("Pinging {server}");
+            let client = ws::WsClient::new(server.clone(), token);
+            let mut ws = client.connect_and_auth().await?;
+            let rtt = client.ping(&mut ws).await?;
+            println!("Pong from {server}: RTT {rtt}ms");
+        }
+        Commands::Health { server } => {
+            // Convert ws:// to http:// if needed, or use as-is
+            let url = if server.starts_with("ws://") {
+                server.replacen("ws://", "http://", 1)
+            } else if server.starts_with("wss://") {
+                server.replacen("wss://", "https://", 1)
+            } else {
+                server
+            };
+            let health_url = format!("{url}/health");
+            info!("Checking health at {health_url}");
+            let resp = reqwest::get(&health_url)
+                .await
+                .map_err(|e| anyhow::anyhow!("HTTP request failed: {e}"))?;
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            println!("HTTP {status}: {body}");
+        }
+        Commands::Tui { server, token } => {
+            tui::run(server, token).await?;
+        }
+    }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn cli_connect_parses() {
+        let args = Cli::try_parse_from([
+            "gyre",
+            "connect",
+            "--server",
+            "ws://host:3000/ws",
+            "--token",
+            "tok",
+        ]);
+        assert!(args.is_ok());
+        let cli = args.unwrap();
+        if let Commands::Connect { server, token } = cli.command {
+            assert_eq!(server, "ws://host:3000/ws");
+            assert_eq!(token, "tok");
+        } else {
+            panic!("Expected Connect");
+        }
+    }
+
+    #[test]
+    fn cli_ping_parses() {
+        let args = Cli::try_parse_from(["gyre", "ping"]);
+        assert!(args.is_ok());
+        if let Commands::Ping { server, token } = args.unwrap().command {
+            assert_eq!(server, DEFAULT_SERVER);
+            assert_eq!(token, DEFAULT_TOKEN);
+        } else {
+            panic!("Expected Ping");
+        }
+    }
+
+    #[test]
+    fn cli_health_parses() {
+        let args = Cli::try_parse_from(["gyre", "health", "--server", "http://myhost:8080"]);
+        assert!(args.is_ok());
+        if let Commands::Health { server } = args.unwrap().command {
+            assert_eq!(server, "http://myhost:8080");
+        } else {
+            panic!("Expected Health");
+        }
+    }
+
+    #[test]
+    fn cli_tui_parses() {
+        let args = Cli::try_parse_from(["gyre", "tui"]);
+        assert!(args.is_ok());
+    }
+
+    #[test]
+    fn cli_verify() {
+        Cli::command().debug_assert();
+    }
 }

--- a/crates/gyre-cli/src/tui.rs
+++ b/crates/gyre-cli/src/tui.rs
@@ -1,0 +1,167 @@
+use anyhow::Result;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+    DefaultTerminal,
+};
+use std::{
+    io,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use crate::ws::WsClient;
+
+#[derive(Clone, PartialEq)]
+pub enum ConnectionStatus {
+    Connecting,
+    Connected,
+    Disconnected,
+}
+
+impl ConnectionStatus {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Connecting => "Connecting...",
+            Self::Connected => "Connected",
+            Self::Disconnected => "Disconnected",
+        }
+    }
+
+    fn color(&self) -> Color {
+        match self {
+            Self::Connecting => Color::Yellow,
+            Self::Connected => Color::Green,
+            Self::Disconnected => Color::Red,
+        }
+    }
+}
+
+struct AppState {
+    status: ConnectionStatus,
+    last_ping_ms: Option<u64>,
+}
+
+pub async fn run(server_url: String, token: String) -> Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let terminal = ratatui::init();
+
+    let result = run_app(terminal, server_url, token).await;
+
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    ratatui::restore();
+    result
+}
+
+async fn run_app(mut terminal: DefaultTerminal, server_url: String, token: String) -> Result<()> {
+    let state = Arc::new(Mutex::new(AppState {
+        status: ConnectionStatus::Connecting,
+        last_ping_ms: None,
+    }));
+
+    // Spawn background task for WS connection and pinging
+    let state_bg = Arc::clone(&state);
+    let url_bg = server_url.clone();
+    let token_bg = token.clone();
+    tokio::spawn(async move {
+        let client = WsClient::new(url_bg, token_bg);
+        match client.connect_and_auth().await {
+            Ok(mut ws) => {
+                {
+                    let mut s = state_bg.lock().unwrap();
+                    s.status = ConnectionStatus::Connected;
+                }
+                loop {
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    match client.ping(&mut ws).await {
+                        Ok(rtt) => {
+                            let mut s = state_bg.lock().unwrap();
+                            s.last_ping_ms = Some(rtt);
+                        }
+                        Err(_) => {
+                            let mut s = state_bg.lock().unwrap();
+                            s.status = ConnectionStatus::Disconnected;
+                            break;
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                let mut s = state_bg.lock().unwrap();
+                s.status = ConnectionStatus::Disconnected;
+            }
+        }
+    });
+
+    let version = env!("CARGO_PKG_VERSION");
+
+    loop {
+        let (status, last_ping) = {
+            let s = state.lock().unwrap();
+            (s.status.clone(), s.last_ping_ms)
+        };
+
+        terminal.draw(|frame| {
+            let area = frame.area();
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Min(0),
+                ])
+                .split(area);
+
+            // Header
+            let header = Paragraph::new(format!("Gyre CLI v{version}"))
+                .block(Block::default().borders(Borders::ALL))
+                .style(Style::default().fg(Color::Cyan));
+            frame.render_widget(header, chunks[0]);
+
+            // Connection status
+            let status_text = Line::from(vec![
+                Span::raw("Status: "),
+                Span::styled(status.label(), Style::default().fg(status.color())),
+            ]);
+            let status_widget = Paragraph::new(status_text)
+                .block(Block::default().borders(Borders::ALL).title("Connection"));
+            frame.render_widget(status_widget, chunks[1]);
+
+            // Ping
+            let ping_text = match last_ping {
+                Some(ms) => format!("Last ping RTT: {ms}ms"),
+                None => "Last ping RTT: --".to_string(),
+            };
+            let ping_widget = Paragraph::new(ping_text)
+                .block(Block::default().borders(Borders::ALL).title("Ping"));
+            frame.render_widget(ping_widget, chunks[2]);
+
+            // Help
+            let help =
+                Paragraph::new("Press q to quit").style(Style::default().fg(Color::DarkGray));
+            frame.render_widget(help, chunks[3]);
+        })?;
+
+        // Poll events with 100ms timeout so the UI refreshes
+        if event::poll(Duration::from_millis(100))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('q') {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/gyre-cli/src/ws.rs
+++ b/crates/gyre-cli/src/ws.rs
@@ -1,0 +1,88 @@
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use gyre_common::WsMessage;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+pub struct WsClient {
+    url: String,
+    token: String,
+}
+
+impl WsClient {
+    pub fn new(url: String, token: String) -> Self {
+        Self { url, token }
+    }
+
+    pub async fn connect_and_auth(
+        &self,
+    ) -> Result<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    > {
+        let (mut ws, _) = connect_async(&self.url)
+            .await
+            .with_context(|| format!("Failed to connect to {}", self.url))?;
+
+        let auth = WsMessage::Auth {
+            token: self.token.clone(),
+        };
+        let msg = serde_json::to_string(&auth)?;
+        ws.send(Message::Text(msg)).await?;
+
+        // Wait for AuthResult
+        while let Some(frame) = ws.next().await {
+            let frame = frame?;
+            if let Message::Text(text) = frame {
+                let msg: WsMessage = serde_json::from_str(&text)?;
+                match msg {
+                    WsMessage::AuthResult { success, message } => {
+                        if success {
+                            println!("Auth: OK - {message}");
+                        } else {
+                            anyhow::bail!("Auth failed: {message}");
+                        }
+                        break;
+                    }
+                    _ => continue,
+                }
+            }
+        }
+
+        Ok(ws)
+    }
+
+    pub async fn ping(
+        &self,
+        ws: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    ) -> Result<u64> {
+        let sent_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        let ping_msg = WsMessage::Ping { timestamp: sent_at };
+        let text = serde_json::to_string(&ping_msg)?;
+        ws.send(Message::Text(text)).await?;
+
+        while let Some(frame) = ws.next().await {
+            let frame = frame?;
+            if let Message::Text(text) = frame {
+                let msg: WsMessage = serde_json::from_str(&text)?;
+                if let WsMessage::Pong { timestamp } = msg {
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis() as u64;
+                    let rtt = now.saturating_sub(timestamp);
+                    return Ok(rtt);
+                }
+            }
+        }
+
+        anyhow::bail!("Connection closed before pong received")
+    }
+}

--- a/crates/gyre-cli/tests/ws_integration.rs
+++ b/crates/gyre-cli/tests/ws_integration.rs
@@ -1,0 +1,83 @@
+use futures_util::{SinkExt, StreamExt};
+use gyre_common::WsMessage;
+use tokio::net::TcpListener;
+use tokio_tungstenite::{accept_async, connect_async, tungstenite::Message};
+
+/// Spawn a minimal mock WebSocket server that handles Auth + Ping.
+/// Returns the WebSocket URL to connect to.
+async fn spawn_mock_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("ws://{addr}");
+
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+
+        while let Some(Ok(msg)) = ws.next().await {
+            if let Message::Text(text) = msg {
+                let parsed: WsMessage = serde_json::from_str(&text).unwrap();
+                match parsed {
+                    WsMessage::Auth { .. } => {
+                        let resp = WsMessage::AuthResult {
+                            success: true,
+                            message: "OK".to_string(),
+                        };
+                        let json = serde_json::to_string(&resp).unwrap();
+                        ws.send(Message::Text(json.into())).await.unwrap();
+                    }
+                    WsMessage::Ping { timestamp } => {
+                        let resp = WsMessage::Pong { timestamp };
+                        let json = serde_json::to_string(&resp).unwrap();
+                        ws.send(Message::Text(json.into())).await.unwrap();
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+
+    url
+}
+
+#[tokio::test]
+async fn test_auth_and_ping_roundtrip() {
+    let url = spawn_mock_server().await;
+
+    let (mut ws, _) = connect_async(&url).await.expect("connect failed");
+
+    // Send Auth
+    let auth = WsMessage::Auth {
+        token: "test-token".to_string(),
+    };
+    ws.send(Message::Text(serde_json::to_string(&auth).unwrap().into()))
+        .await
+        .unwrap();
+
+    // Expect AuthResult
+    let frame = ws.next().await.unwrap().unwrap();
+    let text = if let Message::Text(t) = frame {
+        t
+    } else {
+        panic!("expected text frame")
+    };
+    let msg: WsMessage = serde_json::from_str(&text).unwrap();
+    assert!(matches!(msg, WsMessage::AuthResult { success: true, .. }));
+
+    // Send Ping
+    let ts = 12345u64;
+    let ping = WsMessage::Ping { timestamp: ts };
+    ws.send(Message::Text(serde_json::to_string(&ping).unwrap().into()))
+        .await
+        .unwrap();
+
+    // Expect Pong
+    let frame = ws.next().await.unwrap().unwrap();
+    let text = if let Message::Text(t) = frame {
+        t
+    } else {
+        panic!("expected text frame")
+    };
+    let msg: WsMessage = serde_json::from_str(&text).unwrap();
+    assert!(matches!(msg, WsMessage::Pong { timestamp: 12345 }));
+}

--- a/crates/gyre-common/Cargo.toml
+++ b/crates/gyre-common/Cargo.toml
@@ -9,3 +9,4 @@ license.workspace = true
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/gyre-common/src/lib.rs
+++ b/crates/gyre-common/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod error;
 pub mod id;
+pub mod protocol;
 
 pub use error::GyreError;
 pub use id::Id;
+pub use protocol::WsMessage;

--- a/crates/gyre-common/src/protocol.rs
+++ b/crates/gyre-common/src/protocol.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum WsMessage {
+    Ping { timestamp: u64 },
+    Pong { timestamp: u64 },
+    Auth { token: String },
+    AuthResult { success: bool, message: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ping_roundtrip() {
+        let msg = WsMessage::Ping { timestamp: 999 };
+        let json = serde_json::to_string(&msg).unwrap();
+        let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(decoded, WsMessage::Ping { timestamp: 999 }));
+    }
+
+    #[test]
+    fn pong_roundtrip() {
+        let msg = WsMessage::Pong { timestamp: 42 };
+        let json = serde_json::to_string(&msg).unwrap();
+        let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(decoded, WsMessage::Pong { timestamp: 42 }));
+    }
+
+    #[test]
+    fn auth_roundtrip() {
+        let msg = WsMessage::Auth {
+            token: "my-token".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(decoded, WsMessage::Auth { .. }));
+        if let WsMessage::Auth { token } = decoded {
+            assert_eq!(token, "my-token");
+        }
+    }
+
+    #[test]
+    fn auth_result_roundtrip() {
+        let msg = WsMessage::AuthResult {
+            success: true,
+            message: "OK".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            decoded,
+            WsMessage::AuthResult { success: true, .. }
+        ));
+    }
+
+    #[test]
+    fn ping_json_has_type_tag() {
+        let msg = WsMessage::Ping { timestamp: 1 };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"Ping\""));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `WsMessage` protocol types to `gyre-common` (Ping, Pong, Auth, AuthResult) with serde tagged union encoding
- Implements clap-based `gyre` CLI binary with four subcommands: `connect`, `ping`, `health`, `tui`
- WebSocket client module (`ws.rs`): connect + Auth handshake, ping/pong with RTT measurement
- TUI stub (`tui.rs`): minimal ratatui dashboard showing connection status and last ping RTT, exits on `q`
- Adds workspace dependencies: `clap`, `tokio-tungstenite`, `futures-util`, `url`, `ratatui`, `crossterm`, `reqwest`
- Pins `darling` and `instability` to versions compatible with rustc 1.87.0

## Tests

- 5 unit tests: CLI arg parsing for all subcommands
- 5 unit tests: WsMessage serde round-trips + JSON tag verification
- 1 integration test: mock WebSocket server, full auth + ping/pong flow

## Test plan

- [ ] `cargo test` passes (11 tests)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] `scripts/check-arch.sh` passes

Closes TASK-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)