### PR TITLE
feat(server): M0.2 server boots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Cargo.lock
 *.db
 *.sqlite
 *.sqlite3
+
+# Web app
+web/node_modules/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,22 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# HTTP server
+axum = { version = "0.7", features = ["ws"] }
+tower = "0.4"
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+
+# Storage
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# Static asset embedding
+rust-embed = "8"
+mime_guess = "2"
+
+# Async utilities
+futures-util = "0.3"
+async-trait = "0.1"
+
 # Internal crates
 gyre-common = { path = "crates/gyre-common" }
 gyre-ports = { path = "crates/gyre-ports" }

--- a/crates/gyre-adapters/Cargo.toml
+++ b/crates/gyre-adapters/Cargo.toml
@@ -11,6 +11,10 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
+rusqlite = { workspace = true }
 gyre-common = { workspace = true }
 gyre-ports = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/gyre-adapters/src/sqlite.rs
+++ b/crates/gyre-adapters/src/sqlite.rs
@@ -1,23 +1,70 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use gyre_ports::storage::StoragePort;
+use tracing::instrument;
 
 /// SQLite-backed storage adapter.
 /// Implements the StoragePort for local/development deployments.
 pub struct SqliteStorage {
-    // db_path: String,  // will hold connection pool once rusqlite/sqlx added
+    db_path: String,
 }
 
 impl SqliteStorage {
-    pub fn new(_db_path: impl Into<String>) -> Self {
-        Self {}
+    /// Open (or create) the SQLite database and run initial migrations.
+    pub fn new(db_path: impl Into<String>) -> Result<Self> {
+        let db_path = db_path.into();
+        let conn = rusqlite::Connection::open(&db_path)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS _migrations (
+                id         INTEGER PRIMARY KEY,
+                name       TEXT NOT NULL,
+                applied_at TEXT NOT NULL
+            );",
+        )?;
+        Ok(Self { db_path })
     }
 }
 
 #[async_trait]
 impl StoragePort for SqliteStorage {
+    #[instrument(skip(self), err)]
     async fn health_check(&self) -> Result<()> {
-        // TODO: verify DB file accessible and schema version correct
+        let path = self.db_path.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let conn = rusqlite::Connection::open(&path)?;
+            conn.execute_batch("SELECT 1;")?;
+            Ok(())
+        })
+        .await??;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn health_check_ok() {
+        let tmp = NamedTempFile::new().unwrap();
+        let storage = SqliteStorage::new(tmp.path().to_str().unwrap()).unwrap();
+        storage.health_check().await.unwrap();
+    }
+
+    #[test]
+    fn new_creates_migrations_table() {
+        let tmp = NamedTempFile::new().unwrap();
+        let storage = SqliteStorage::new(tmp.path().to_str().unwrap()).unwrap();
+        // Re-open and verify the table exists.
+        let conn = rusqlite::Connection::open(&storage.db_path).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='_migrations'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/crates/gyre-common/src/lib.rs
+++ b/crates/gyre-common/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod error;
 pub mod id;
+pub mod protocol;
 
 pub use error::GyreError;
 pub use id::Id;
+pub use protocol::WsMessage;

--- a/crates/gyre-common/src/protocol.rs
+++ b/crates/gyre-common/src/protocol.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+/// WebSocket message types shared between server and CLI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum WsMessage {
+    Ping { timestamp: u64 },
+    Pong { timestamp: u64 },
+    Auth { token: String },
+    AuthResult { success: bool, message: String },
+}

--- a/crates/gyre-server/Cargo.toml
+++ b/crates/gyre-server/Cargo.toml
@@ -16,7 +16,18 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+rust-embed = { workspace = true }
+mime_guess = { workspace = true }
+futures-util = { workspace = true }
 gyre-common = { workspace = true }
 gyre-ports = { workspace = true }
 gyre-domain = { workspace = true }
 gyre-adapters = { workspace = true }
+
+[dev-dependencies]
+tokio-tungstenite = "0.24"
+http = "1"
+tower = { workspace = true, features = ["util"] }

--- a/crates/gyre-server/src/health.rs
+++ b/crates/gyre-server/src/health.rs
@@ -1,0 +1,56 @@
+use axum::{http::StatusCode, response::IntoResponse, Json};
+use serde_json::json;
+use tracing::instrument;
+
+/// GET /health - returns {"status":"ok","version":"0.1.0"}
+#[instrument]
+pub async fn health_handler() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(json!({"status": "ok", "version": "0.1.0"})),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, routing::get, Router};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn health_returns_200() {
+        let app = Router::new().route("/health", get(health_handler));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn health_returns_correct_json() {
+        let app = Router::new().route("/health", get(health_handler));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["version"], "0.1.0");
+    }
+}

--- a/crates/gyre-server/src/main.rs
+++ b/crates/gyre-server/src/main.rs
@@ -1,5 +1,29 @@
+mod health;
+mod spa;
+mod ws;
+
 use anyhow::Result;
+use axum::{routing::get, Router};
+use gyre_adapters::sqlite::SqliteStorage;
+use gyre_ports::storage::StoragePort;
+use std::sync::Arc;
 use tracing::info;
+
+/// Shared application state available to all handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub auth_token: String,
+}
+
+/// Build the axum Router (extracted for testability).
+pub fn build_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/health", get(health::health_handler))
+        .route("/ws", get(ws::ws_handler))
+        .route("/", get(spa::spa_handler))
+        .route("/*path", get(spa::spa_handler))
+        .with_state(state)
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -12,8 +36,95 @@ async fn main() -> Result<()> {
 
     info!("gyre-server starting");
 
-    // TODO(m0.2): wire up axum HTTP server, WebSocket endpoint, health check
-    // See: specs/milestones/m0-walking-skeleton.md - Deliverable 2: Server Boots
+    let port: u16 = std::env::var("GYRE_PORT")
+        .unwrap_or_else(|_| "3000".to_string())
+        .parse()?;
 
+    let auth_token =
+        std::env::var("GYRE_AUTH_TOKEN").unwrap_or_else(|_| "gyre-dev-token".to_string());
+
+    let db_path = std::env::var("GYRE_DB_PATH").unwrap_or_else(|_| "gyre.db".to_string());
+
+    // Initialize SQLite storage and verify connectivity.
+    let storage = tokio::task::spawn_blocking(move || SqliteStorage::new(&db_path)).await??;
+    storage.health_check().await?;
+    info!("storage healthy");
+
+    let state = Arc::new(AppState { auth_token });
+    let app = build_router(state);
+
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    info!(%addr, "listening");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    info!("gyre-server stopped");
     Ok(())
+}
+
+/// Wait for SIGINT or SIGTERM.
+async fn shutdown_signal() {
+    use tokio::signal;
+
+    let ctrl_c = async {
+        signal::ctrl_c().await.expect("failed to listen for ctrl-c");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+
+    info!("shutdown signal received");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, Router};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn test_app() -> Router {
+        let state = Arc::new(AppState {
+            auth_token: "test-token".to_string(),
+        });
+        build_router(state)
+    }
+
+    #[tokio::test]
+    async fn integration_health_endpoint() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["version"], "0.1.0");
+    }
 }

--- a/crates/gyre-server/src/spa.rs
+++ b/crates/gyre-server/src/spa.rs
@@ -1,0 +1,38 @@
+use axum::{http::header, response::IntoResponse};
+use mime_guess::from_path;
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "../../web/dist"]
+struct Asset;
+
+/// Serve the embedded Svelte SPA. Falls back to index.html for client-side routing.
+pub async fn spa_handler(uri: axum::http::Uri) -> impl IntoResponse {
+    let path = uri.path().trim_start_matches('/');
+    let path = if path.is_empty() { "index.html" } else { path };
+    serve_asset(path)
+}
+
+fn serve_asset(path: &str) -> axum::response::Response {
+    match Asset::get(path) {
+        Some(content) => {
+            let mime = from_path(path).first_or_octet_stream();
+            (
+                [(header::CONTENT_TYPE, mime.as_ref().to_owned())],
+                content.data.into_owned(),
+            )
+                .into_response()
+        }
+        None => {
+            // Serve index.html for SPA client-side routing.
+            match Asset::get("index.html") {
+                Some(content) => (
+                    [(header::CONTENT_TYPE, "text/html; charset=utf-8".to_owned())],
+                    content.data.into_owned(),
+                )
+                    .into_response(),
+                None => axum::http::StatusCode::NOT_FOUND.into_response(),
+            }
+        }
+    }
+}

--- a/crates/gyre-server/src/ws.rs
+++ b/crates/gyre-server/src/ws.rs
@@ -1,0 +1,215 @@
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::IntoResponse,
+};
+use futures_util::{SinkExt, StreamExt};
+use gyre_common::WsMessage;
+use std::sync::Arc;
+use tracing::{info, instrument, warn};
+
+use crate::AppState;
+
+/// GET /ws - WebSocket upgrade endpoint.
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state.auth_token.clone()))
+}
+
+#[instrument(skip(socket, auth_token))]
+async fn handle_socket(socket: WebSocket, auth_token: String) {
+    info!("WebSocket connection opened");
+    let (mut sender, mut receiver) = socket.split();
+
+    // Expect first message to be Auth.
+    let authed = match receiver.next().await {
+        Some(Ok(Message::Text(text))) => authenticate(&text, &auth_token, &mut sender).await,
+        Some(Ok(Message::Close(_))) | None => {
+            info!("connection closed before auth");
+            return;
+        }
+        other => {
+            warn!(?other, "unexpected first message, closing");
+            return;
+        }
+    };
+
+    if !authed {
+        return;
+    }
+
+    // Main message loop: respond to Ping with Pong.
+    while let Some(msg) = receiver.next().await {
+        match msg {
+            Ok(Message::Text(text)) => {
+                if let Ok(ws_msg) = serde_json::from_str::<WsMessage>(&text) {
+                    match ws_msg {
+                        WsMessage::Ping { timestamp } => {
+                            let pong = WsMessage::Pong { timestamp };
+                            let payload = serde_json::to_string(&pong).unwrap();
+                            if sender.send(Message::Text(payload)).await.is_err() {
+                                break;
+                            }
+                        }
+                        other => {
+                            warn!(?other, "unexpected message type after auth");
+                        }
+                    }
+                } else {
+                    warn!(%text, "failed to parse WebSocket message");
+                }
+            }
+            Ok(Message::Close(_)) => break,
+            Err(e) => {
+                warn!(%e, "WebSocket error");
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    info!("WebSocket connection closed");
+}
+
+/// Send AuthResult and return true if token is valid.
+#[instrument(skip(token_json, sender, auth_token))]
+async fn authenticate(
+    token_json: &str,
+    auth_token: &str,
+    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+) -> bool {
+    match serde_json::from_str::<WsMessage>(token_json) {
+        Ok(WsMessage::Auth { token }) => {
+            let success = token == auth_token;
+            let result = if success {
+                WsMessage::AuthResult {
+                    success: true,
+                    message: "authenticated".to_string(),
+                }
+            } else {
+                warn!("authentication failed: invalid token");
+                WsMessage::AuthResult {
+                    success: false,
+                    message: "invalid token".to_string(),
+                }
+            };
+            let payload = serde_json::to_string(&result).unwrap();
+            let _ = sender.send(Message::Text(payload)).await;
+            success
+        }
+        _ => {
+            warn!("expected Auth message, got something else");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build_router;
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite;
+
+    async fn start_test_server(auth_token: &str) -> String {
+        let state = Arc::new(AppState {
+            auth_token: auth_token.to_string(),
+        });
+        let app = build_router(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("ws://127.0.0.1:{}/ws", addr.port())
+    }
+
+    #[tokio::test]
+    async fn ws_valid_auth_succeeds() {
+        let url = start_test_server("test-token").await;
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+        let auth = WsMessage::Auth {
+            token: "test-token".to_string(),
+        };
+        ws.send(tungstenite::Message::Text(
+            serde_json::to_string(&auth).unwrap(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = ws.next().await.unwrap().unwrap();
+        if let tungstenite::Message::Text(text) = msg {
+            let result: WsMessage = serde_json::from_str(&text).unwrap();
+            assert!(matches!(
+                result,
+                WsMessage::AuthResult { success: true, .. }
+            ));
+        } else {
+            panic!("expected text message");
+        }
+    }
+
+    #[tokio::test]
+    async fn ws_invalid_auth_fails() {
+        let url = start_test_server("real-token").await;
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+        let auth = WsMessage::Auth {
+            token: "wrong-token".to_string(),
+        };
+        ws.send(tungstenite::Message::Text(
+            serde_json::to_string(&auth).unwrap(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = ws.next().await.unwrap().unwrap();
+        if let tungstenite::Message::Text(text) = msg {
+            let result: WsMessage = serde_json::from_str(&text).unwrap();
+            assert!(matches!(
+                result,
+                WsMessage::AuthResult { success: false, .. }
+            ));
+        } else {
+            panic!("expected text message");
+        }
+    }
+
+    #[tokio::test]
+    async fn ws_ping_pong() {
+        let url = start_test_server("tok").await;
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+        // Auth first
+        let auth = WsMessage::Auth {
+            token: "tok".to_string(),
+        };
+        ws.send(tungstenite::Message::Text(
+            serde_json::to_string(&auth).unwrap(),
+        ))
+        .await
+        .unwrap();
+        ws.next().await.unwrap().unwrap(); // consume AuthResult
+
+        // Send Ping
+        let ping = WsMessage::Ping { timestamp: 42 };
+        ws.send(tungstenite::Message::Text(
+            serde_json::to_string(&ping).unwrap(),
+        ))
+        .await
+        .unwrap();
+
+        let msg = ws.next().await.unwrap().unwrap();
+        if let tungstenite::Message::Text(text) = msg {
+            let result: WsMessage = serde_json::from_str(&text).unwrap();
+            assert!(matches!(result, WsMessage::Pong { timestamp: 42 }));
+        } else {
+            panic!("expected text message");
+        }
+    }
+}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gyre</title>
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 640px; margin: 4rem auto; text-align: center; }
+      h1 { font-size: 3rem; font-weight: 700; }
+      .status { color: #f97316; }
+      .version { color: #999; font-size: 0.9rem; margin-top: 2rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Gyre</h1>
+    <p>Connection: <span class="status">disconnected</span></p>
+    <p class="version">v0.1.0</p>
+    <script>
+      // Minimal WS client (stub build — run `npm run build` in web/ for the full app)
+      const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const ws = new WebSocket(`${protocol}//${location.host}/ws`);
+      const statusEl = document.querySelector('.status');
+      ws.onopen = () => ws.send(JSON.stringify({ type: 'Auth', token: 'gyre-dev-token' }));
+      ws.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+        if (msg.type === 'AuthResult') {
+          statusEl.textContent = msg.success ? 'connected' : 'auth-failed';
+          statusEl.style.color = msg.success ? '#22c55e' : '#ef4444';
+        }
+      };
+      ws.onclose = () => { statusEl.textContent = 'disconnected'; };
+    </script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gyre</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gyre-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "svelte": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,0 +1,74 @@
+<script>
+  const version = '0.1.0';
+  let connectionStatus = $state('disconnected');
+
+  $effect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${protocol}//${window.location.host}/ws`;
+    let ws;
+
+    function connect() {
+      ws = new WebSocket(wsUrl);
+
+      ws.onopen = () => {
+        ws.send(JSON.stringify({ type: 'Auth', token: 'gyre-dev-token' }));
+      };
+
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data);
+        if (msg.type === 'AuthResult') {
+          connectionStatus = msg.success ? 'connected' : 'auth-failed';
+        }
+      };
+
+      ws.onclose = () => {
+        connectionStatus = 'disconnected';
+      };
+
+      ws.onerror = () => {
+        connectionStatus = 'error';
+      };
+    }
+
+    connect();
+    return () => ws?.close();
+  });
+</script>
+
+<main>
+  <h1>Gyre</h1>
+  <p class="status">Connection: <span class={connectionStatus}>{connectionStatus}</span></p>
+  <p class="version">v{version}</p>
+</main>
+
+<style>
+  main {
+    font-family: system-ui, sans-serif;
+    max-width: 640px;
+    margin: 4rem auto;
+    padding: 0 1rem;
+    text-align: center;
+  }
+
+  h1 {
+    font-size: 3rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+
+  .status {
+    font-size: 1.1rem;
+    color: #555;
+  }
+
+  .connected { color: #22c55e; }
+  .disconnected { color: #f97316; }
+  .error { color: #ef4444; }
+  .auth-failed { color: #ef4444; }
+
+  .version {
+    margin-top: 2rem;
+    color: #999;
+    font-size: 0.9rem;
+  }
+</style>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,0 +1,6 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, { target: document.getElementById('app') });
+
+export default app;

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary

Implements TASK-003: M0.2 Server Boots — everything needed for the gyre-server to start, accept connections, and pass all tests.

- **Protocol types**: `WsMessage` enum (Ping/Pong/Auth/AuthResult) in `gyre-common`, serializable via serde_json with `#[serde(tag = "type")]`
- **HTTP server** (axum 0.7): `GET /health` JSON, `GET /ws` WebSocket upgrade, `GET /` + `GET /*path` Svelte SPA
- **WebSocket handler**: token auth via `GYRE_AUTH_TOKEN` env (default `gyre-dev-token`), Ping→Pong loop, tracing spans
- **SQLite adapter** (rusqlite bundled): `StoragePort` impl, migrations table init, async `health_check()` via `spawn_blocking`
- **Svelte 5 SPA**: `web/` with vite + `@sveltejs/vite-plugin-svelte`, pre-built stub in `web/dist/` committed for zero-npm-install builds
- **Graceful shutdown**: SIGINT + SIGTERM via `tokio::signal`
- **Tracing**: `tracing-subscriber` with `RUST_LOG` env filter, `#[instrument]` on handlers

## Tests (8 passing)

- `health_returns_200` — oneshot GET /health → 200
- `health_returns_correct_json` — body matches `{"status":"ok","version":"0.1.0"}`
- `integration_health_endpoint` — via `build_router` oneshot
- `ws_valid_auth_succeeds` — real listener, tokio-tungstenite client
- `ws_invalid_auth_fails` — wrong token → `AuthResult { success: false }`
- `ws_ping_pong` — auth then Ping 42 → Pong 42
- `health_check_ok` — SQLite `StoragePort::health_check()`
- `new_creates_migrations_table` — `_migrations` table exists after init

## Architecture

Hexagonal boundary maintained: `gyre-domain` does not import axum, rusqlite, or any infra crate (arch lint passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)