### PR TITLE
docs(agents): add server runtime section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 |--------|------|-------------|
 | `GET` | `/health` | Returns `{"status":"ok","version":"0.1.0"}` |
 | `GET` | `/ws` | WebSocket upgrade (requires `Auth` handshake first) |
+| `GET` | `/api/activity` | Query activity log (params: `since=<unix_ms>`, `limit=<n>`) |
 | `GET` | `/*` | Svelte SPA static files (served from `web/dist/`) |
 
 ### Server Environment Variables
@@ -95,22 +96,52 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 
 ### WebSocket Protocol (`gyre-common::WsMessage`)
 
-All WS messages are JSON with a `"type"` discriminant. Auth must be the first message:
+All WS messages are JSON with a `"type"` discriminant. Auth must be the first message.
+See `crates/gyre-common/src/protocol.rs` for the full type definitions.
 
 ```json
-// Client sends first:
+// 1. Auth handshake (required first):
 {"type":"Auth","token":"gyre-dev-token"}
-// Server replies:
 {"type":"AuthResult","success":true,"message":"authenticated"}
 
-// Liveness probe:
+// 2. Liveness probe:
 {"type":"Ping","timestamp":1234567890}
-// Server echoes:
 {"type":"Pong","timestamp":1234567890}
+
+// 3. Record an activity event (server stores + broadcasts to all clients):
+{"type":"ActivityEvent","event_id":"abc","agent_id":"server","event_type":"task.started","description":"Task started","timestamp":1234567890}
+
+// 4. Query activity log over WebSocket:
+{"type":"ActivityQuery","since":1234567800,"limit":50}
+{"type":"ActivityResponse","events":[...]}
 ```
+
+The in-memory `ActivityStore` holds up to 1000 events (oldest dropped when full).
+The same events are also queryable via `GET /api/activity?since=<ts>&limit=<n>`.
 
 > `web/dist/` is committed so the server can serve the SPA without requiring `npm` at build
 > time. Agents and CI do not need Node installed to build or run `gyre-server`.
+
+---
+
+## CLI Usage
+
+```bash
+# Connect to a running gyre-server (interactive session)
+gyre connect --server ws://localhost:3000/ws --token gyre-dev-token
+
+# Ping the server and measure round-trip time
+gyre ping --server ws://localhost:3000/ws --token gyre-dev-token
+
+# Check server health via HTTP
+gyre health --server http://localhost:3000
+
+# Launch the TUI dashboard (exits on 'q')
+gyre tui --server ws://localhost:3000/ws --token gyre-dev-token
+```
+
+Default `--server` is `ws://localhost:3000/ws` and default `--token` is `gyre-dev-token`
+(matches server defaults, so bare `gyre ping` works against a local dev server).
 
 ---
 

--- a/crates/gyre-cli/tests/ws_integration.rs
+++ b/crates/gyre-cli/tests/ws_integration.rs
@@ -24,12 +24,12 @@ async fn spawn_mock_server() -> String {
                             message: "OK".to_string(),
                         };
                         let json = serde_json::to_string(&resp).unwrap();
-                        ws.send(Message::Text(json.into())).await.unwrap();
+                        ws.send(Message::Text(json)).await.unwrap();
                     }
                     WsMessage::Ping { timestamp } => {
                         let resp = WsMessage::Pong { timestamp };
                         let json = serde_json::to_string(&resp).unwrap();
-                        ws.send(Message::Text(json.into())).await.unwrap();
+                        ws.send(Message::Text(json)).await.unwrap();
                     }
                     _ => {}
                 }
@@ -50,7 +50,7 @@ async fn test_auth_and_ping_roundtrip() {
     let auth = WsMessage::Auth {
         token: "test-token".to_string(),
     };
-    ws.send(Message::Text(serde_json::to_string(&auth).unwrap().into()))
+    ws.send(Message::Text(serde_json::to_string(&auth).unwrap()))
         .await
         .unwrap();
 
@@ -67,7 +67,7 @@ async fn test_auth_and_ping_roundtrip() {
     // Send Ping
     let ts = 12345u64;
     let ping = WsMessage::Ping { timestamp: ts };
-    ws.send(Message::Text(serde_json::to_string(&ping).unwrap().into()))
+    ws.send(Message::Text(serde_json::to_string(&ping).unwrap()))
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

- Adds **Running the Server** section to \`AGENTS.md\`: start commands, endpoint table (including M0.4a \`/api/activity\`), env vars, and full WS protocol examples (Auth/Ping/ActivityEvent/ActivityQuery)
- Adds **CLI Usage** section: all 4 subcommands (\`connect\`, \`ping\`, \`health\`, \`tui\`) with example invocations
- Documents \`ActivityStore\` 1000-event capacity and REST+WS query interface (M0.4a)
- **Fixes clippy CI failure**: removes 4 redundant \`.into()\` calls in \`crates/gyre-cli/tests/ws_integration.rs\` that were causing \`clippy::useless_conversion\` errors on every CI run

## Background

- PR #3 (server) and direct main pushes (CLI + M0.4a) landed without updating \`AGENTS.md\`.
- The clippy lint failure was blocking CI on all open PRs. This PR fixes the root cause.

## Test plan

- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes (verified locally)
- [x] \`cargo fmt --all -- --check\` passes
- [x] \`bash scripts/check-arch.sh\` passes (no source structure changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)