### PR TITLE
feat(server): M0.4b Ralph Loop Demo — add GET /api/version endpoint

### DIFF
--- a/crates/gyre-cli/tests/ws_integration.rs
+++ b/crates/gyre-cli/tests/ws_integration.rs
@@ -24,12 +24,12 @@ async fn spawn_mock_server() -> String {
                             message: "OK".to_string(),
                         };
                         let json = serde_json::to_string(&resp).unwrap();
-                        ws.send(Message::Text(json.into())).await.unwrap();
+                        ws.send(Message::Text(json)).await.unwrap();
                     }
                     WsMessage::Ping { timestamp } => {
                         let resp = WsMessage::Pong { timestamp };
                         let json = serde_json::to_string(&resp).unwrap();
-                        ws.send(Message::Text(json.into())).await.unwrap();
+                        ws.send(Message::Text(json)).await.unwrap();
                     }
                     _ => {}
                 }
@@ -50,7 +50,7 @@ async fn test_auth_and_ping_roundtrip() {
     let auth = WsMessage::Auth {
         token: "test-token".to_string(),
     };
-    ws.send(Message::Text(serde_json::to_string(&auth).unwrap().into()))
+    ws.send(Message::Text(serde_json::to_string(&auth).unwrap()))
         .await
         .unwrap();
 
@@ -67,7 +67,7 @@ async fn test_auth_and_ping_roundtrip() {
     // Send Ping
     let ts = 12345u64;
     let ping = WsMessage::Ping { timestamp: ts };
-    ws.send(Message::Text(serde_json::to_string(&ping).unwrap().into()))
+    ws.send(Message::Text(serde_json::to_string(&ping).unwrap()))
         .await
         .unwrap();
 

--- a/crates/gyre-server/src/main.rs
+++ b/crates/gyre-server/src/main.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod health;
 mod spa;
+mod version;
 mod ws;
 
 use anyhow::Result;
@@ -30,6 +31,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health::health_handler))
         .route("/ws", get(ws::ws_handler))
+        .route("/api/version", get(version::version_handler))
         .route("/api/activity", get(activity_query_handler))
         .route("/", get(spa::spa_handler))
         .route("/*path", get(spa::spa_handler))

--- a/crates/gyre-server/src/version.rs
+++ b/crates/gyre-server/src/version.rs
@@ -1,0 +1,58 @@
+use axum::{response::IntoResponse, Json};
+use serde_json::json;
+use tracing::instrument;
+
+/// GET /api/version - returns gyre server version info.
+#[instrument]
+pub async fn version_handler() -> impl IntoResponse {
+    Json(json!({
+        "name": "gyre",
+        "version": "0.1.0",
+        "milestone": "M0"
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, routing::get, Router};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn version_returns_200() {
+        let app = Router::new().route("/api/version", get(version_handler));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/version")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn version_returns_correct_json() {
+        let app = Router::new().route("/api/version", get(version_handler));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/version")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["name"], "gyre");
+        assert_eq!(json["version"], "0.1.0");
+        assert_eq!(json["milestone"], "M0");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/version` endpoint returning `{"name":"gyre","version":"0.1.0","milestone":"M0"}`
- Fixes pre-existing `clippy::useless_conversion` warnings in `gyre-cli/tests/ws_integration.rs`
- Includes 2 new unit tests for the version endpoint
- All 27 tests pass (`cargo test --all`)

## Ralph Loop Activity Trail

This PR was produced by ralph-demo executing the full M0.4b loop:
1. **CONNECT** — authenticated to gyre WS server
2. **IMPLEMENT** — added `/api/version` endpoint
3. **SELF_REVIEW** — fmt ✓, clippy -D warnings ✓, arch-lint ✓
4. **TEST** — 27/27 tests pass
5. **OPEN_PR** — this PR

Activity events logged to `http://localhost:3333/api/activity` (agent_id: ralph-demo).

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `bash scripts/check-arch.sh` passes
- [x] `cargo test --all` — 27 tests pass
- [x] `curl http://localhost:3333/api/version` returns expected JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)