### PR TITLE
feat: M1.5 Agent Lifecycle via API

### DIFF
--- a/crates/gyre-server/src/api/agent_messages.rs
+++ b/crates/gyre-server/src/api/agent_messages.rs
@@ -1,0 +1,216 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use gyre_common::Id;
+use serde::Deserialize;
+use std::sync::Arc;
+
+use crate::messages::AgentMessage;
+use crate::AppState;
+
+use super::error::ApiError;
+use super::{new_id, now_secs};
+
+#[derive(Deserialize)]
+pub struct SendMessageRequest {
+    pub from: String,
+    pub content: serde_json::Value,
+}
+
+/// GET /api/v1/agents/{id}/messages — drain and return pending messages.
+pub async fn get_messages(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<AgentMessage>>, ApiError> {
+    state
+        .agents
+        .find_by_id(&Id::new(&id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("agent {id} not found")))?;
+
+    let mut store = state.agent_messages.lock().await;
+    let messages: Vec<AgentMessage> = store
+        .get_mut(&id)
+        .map(|q| q.drain(..).collect())
+        .unwrap_or_default();
+    Ok(Json(messages))
+}
+
+/// POST /api/v1/agents/{id}/messages — deliver a message to an agent's inbox.
+pub async fn send_message(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<SendMessageRequest>,
+) -> Result<(StatusCode, Json<AgentMessage>), ApiError> {
+    state
+        .agents
+        .find_by_id(&Id::new(&id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("agent {id} not found")))?;
+
+    let msg = AgentMessage {
+        id: new_id().to_string(),
+        from: req.from,
+        content: req.content,
+        created_at: now_secs(),
+    };
+
+    state
+        .agent_messages
+        .lock()
+        .await
+        .entry(id)
+        .or_default()
+        .push_back(msg.clone());
+
+    Ok((StatusCode::CREATED, Json(msg)))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mem::test_state;
+    use axum::{body::Body, Router};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn app() -> Router {
+        crate::api::api_router().with_state(test_state())
+    }
+
+    async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn create_agent(app: Router, name: &str) -> (Router, String) {
+        let body = serde_json::json!({ "name": name });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let json = body_json(resp).await;
+        let id = json["id"].as_str().unwrap().to_string();
+        (app, id)
+    }
+
+    #[tokio::test]
+    async fn send_and_receive_message() {
+        let app = app();
+        let (app, id) = create_agent(app, "msg-agent").await;
+
+        // Send a message
+        let body = serde_json::json!({ "from": "CEO", "content": "hello agent" });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/agents/{id}/messages"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        assert_eq!(json["from"], "CEO");
+        assert_eq!(json["content"], "hello agent");
+
+        // Poll messages — should drain the inbox
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/agents/{id}/messages"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        let msgs = json.as_array().unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0]["from"], "CEO");
+
+        // Second poll — inbox should be empty
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/agents/{id}/messages"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn send_message_to_unknown_agent() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/agents/ghost/messages")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"from":"x","content":"y"}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn multiple_messages_queued() {
+        let app = app();
+        let (app, id) = create_agent(app, "queue-agent").await;
+
+        for i in 0..3u32 {
+            let body = serde_json::json!({ "from": "CEO", "content": i });
+            app.clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!("/api/v1/agents/{id}/messages"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/agents/{id}/messages"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json.as_array().unwrap().len(), 3);
+    }
+}

--- a/crates/gyre-server/src/api/agents.rs
+++ b/crates/gyre-server/src/api/agents.rs
@@ -40,6 +40,14 @@ pub struct AgentResponse {
     pub last_heartbeat: Option<u64>,
 }
 
+/// Returned only from POST /api/v1/agents — includes a one-time auth token.
+#[derive(Serialize)]
+pub struct RegisterAgentResponse {
+    #[serde(flatten)]
+    pub agent: AgentResponse,
+    pub auth_token: String,
+}
+
 impl From<Agent> for AgentResponse {
     fn from(a: Agent) -> Self {
         Self {
@@ -68,12 +76,26 @@ fn parse_agent_status(s: &str) -> Result<AgentStatus, ApiError> {
 pub async fn create_agent(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateAgentRequest>,
-) -> Result<(StatusCode, Json<AgentResponse>), ApiError> {
+) -> Result<(StatusCode, Json<RegisterAgentResponse>), ApiError> {
     let now = now_secs();
     let mut agent = Agent::new(new_id(), req.name, now);
     agent.parent_id = req.parent_id.map(Id::new);
     state.agents.create(&agent).await?;
-    Ok((StatusCode::CREATED, Json(AgentResponse::from(agent))))
+
+    let token = uuid::Uuid::new_v4().to_string();
+    state
+        .agent_tokens
+        .lock()
+        .await
+        .insert(agent.id.to_string(), token.clone());
+
+    Ok((
+        StatusCode::CREATED,
+        Json(RegisterAgentResponse {
+            agent: AgentResponse::from(agent),
+            auth_token: token,
+        }),
+    ))
 }
 
 pub async fn list_agents(
@@ -165,9 +187,31 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
         let json = body_json(resp).await;
         let id = json["id"].as_str().unwrap().to_string();
         (app, id)
+    }
+
+    #[tokio::test]
+    async fn create_agent_returns_auth_token() {
+        let app = app();
+        let body = serde_json::json!({ "name": "token-agent" });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        assert!(json["auth_token"].as_str().is_some());
+        assert!(!json["auth_token"].as_str().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/gyre-server/src/api/mod.rs
+++ b/crates/gyre-server/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod agent_messages;
 pub mod agents;
 pub mod error;
 pub mod merge_requests;
@@ -48,6 +49,10 @@ pub fn api_router() -> Router<Arc<AppState>> {
             put(agents::update_agent_status),
         )
         .route("/api/v1/agents/:id/heartbeat", put(agents::agent_heartbeat))
+        .route(
+            "/api/v1/agents/:id/messages",
+            get(agent_messages::get_messages).post(agent_messages::send_message),
+        )
         // Tasks
         .route(
             "/api/v1/tasks",

--- a/crates/gyre-server/src/main.rs
+++ b/crates/gyre-server/src/main.rs
@@ -2,17 +2,21 @@ mod activity;
 mod api;
 mod health;
 mod mem;
+mod messages;
 mod spa;
 mod ws;
 
 use anyhow::Result;
 use axum::{routing::get, Router};
 use gyre_common::ActivityEventData;
+use gyre_domain::AgentStatus;
 use gyre_ports::{
     AgentRepository, MergeRequestRepository, ProjectRepository, RepoRepository, TaskRepository,
 };
+use messages::AgentMessage;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Mutex};
 use tracing::info;
 
 /// Shared application state available to all handlers.
@@ -26,6 +30,10 @@ pub struct AppState {
     pub merge_requests: Arc<dyn MergeRequestRepository>,
     pub activity_store: activity::ActivityStore,
     pub broadcast_tx: broadcast::Sender<ActivityEventData>,
+    /// Per-agent message inboxes: agent_id → queued messages.
+    pub agent_messages: Arc<Mutex<HashMap<String, VecDeque<AgentMessage>>>>,
+    /// Auth tokens issued on agent registration: agent_id → token.
+    pub agent_tokens: Arc<Mutex<HashMap<String, String>>>,
 }
 
 /// Build the axum Router (extracted for testability).
@@ -67,7 +75,13 @@ async fn main() -> Result<()> {
         merge_requests: Arc::new(mem::MemMrRepository::default()),
         activity_store: activity::ActivityStore::new(),
         broadcast_tx,
+        agent_messages: Arc::new(Mutex::new(HashMap::new())),
+        agent_tokens: Arc::new(Mutex::new(HashMap::new())),
     });
+
+    // Background task: mark agents dead if they miss heartbeats.
+    spawn_stale_agent_detector(state.clone());
+
     let app = build_router(state);
 
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
@@ -80,6 +94,42 @@ async fn main() -> Result<()> {
 
     info!("gyre-server stopped");
     Ok(())
+}
+
+/// Periodically scan for agents that have stopped sending heartbeats and mark them Dead.
+fn spawn_stale_agent_detector(state: Arc<AppState>) {
+    const CHECK_INTERVAL_SECS: u64 = 30;
+    const HEARTBEAT_TIMEOUT_SECS: u64 = 60;
+
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(tokio::time::Duration::from_secs(CHECK_INTERVAL_SECS));
+        loop {
+            interval.tick().await;
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            match state.agents.list().await {
+                Ok(agents) => {
+                    for mut agent in agents {
+                        if agent.status != AgentStatus::Dead
+                            && !agent.is_alive(now, HEARTBEAT_TIMEOUT_SECS)
+                        {
+                            info!(agent_id = %agent.id, agent_name = %agent.name,
+                                  "marking stale agent as dead");
+                            let _ = agent.transition_status(AgentStatus::Dead);
+                            let _ = state.agents.update(&agent).await;
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("stale agent check failed: {e}");
+                }
+            }
+        }
+    });
 }
 
 /// Wait for SIGINT or SIGTERM.

--- a/crates/gyre-server/src/mem.rs
+++ b/crates/gyre-server/src/mem.rs
@@ -290,7 +290,8 @@ impl MergeRequestRepository for MemMrRepository {
 /// Build an AppState with all in-memory repositories for tests.
 #[cfg(test)]
 pub fn test_state() -> Arc<crate::AppState> {
-    use tokio::sync::broadcast;
+    use std::collections::HashMap;
+    use tokio::sync::{broadcast, Mutex};
     Arc::new(crate::AppState {
         auth_token: "test-token".to_string(),
         projects: Arc::new(MemProjectRepository::default()),
@@ -300,5 +301,7 @@ pub fn test_state() -> Arc<crate::AppState> {
         merge_requests: Arc::new(MemMrRepository::default()),
         activity_store: crate::activity::ActivityStore::new(),
         broadcast_tx: broadcast::channel(16).0,
+        agent_messages: Arc::new(Mutex::new(HashMap::new())),
+        agent_tokens: Arc::new(Mutex::new(HashMap::new())),
     })
 }

--- a/crates/gyre-server/src/messages.rs
+++ b/crates/gyre-server/src/messages.rs
@@ -1,0 +1,11 @@
+//! Agent message inbox types.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentMessage {
+    pub id: String,
+    pub from: String,
+    pub content: serde_json::Value,
+    pub created_at: u64,
+}


### PR DESCRIPTION
## Summary

- `POST /api/v1/agents` now returns `auth_token` (UUID) on registration
- `GET /api/v1/agents/{id}/messages` — drains and returns the agent's inbox (polling pattern)
- `POST /api/v1/agents/{id}/messages` — delivers a message to an agent's inbox
- Background task (`spawn_stale_agent_detector`) marks agents as `Dead` after 60s without a heartbeat (checked every 30s)

## Implementation details

- `src/messages.rs` — shared `AgentMessage` type (id, from, content, created_at)
- `AppState` gains `agent_messages: Arc<Mutex<HashMap<String, VecDeque<AgentMessage>>>>` and `agent_tokens: Arc<Mutex<HashMap<String, String>>>`
- Messages drain on poll (no persistence needed for M1)

## Test plan

- [x] `create_agent_returns_auth_token` — registration response includes non-empty token
- [x] `send_and_receive_message` — message delivered, inbox drained on first poll, empty on second
- [x] `multiple_messages_queued` — 3 messages arrive, all returned in single poll
- [x] `send_message_to_unknown_agent` — returns 404
- [x] 42 total tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)