### PR TITLE
fix(server): gate NoopGitOps + test-only imports with #[cfg(test)]

### DIFF
--- a/crates/gyre-server/src/mem.rs
+++ b/crates/gyre-server/src/mem.rs
@@ -4,23 +4,28 @@ use anyhow::Result;
 use async_trait::async_trait;
 use gyre_common::Id;
 use gyre_domain::{
-    Agent, AgentCommit, AgentStatus, AgentWorktree, BranchInfo, CommitInfo, DiffResult,
-    MergeQueueEntry, MergeQueueEntryStatus, MergeRequest, MergeResult, MrStatus, Project,
-    Repository, Review, ReviewComment, ReviewDecision, Task, TaskStatus,
+    Agent, AgentCommit, AgentStatus, AgentWorktree, MergeQueueEntry, MergeQueueEntryStatus,
+    MergeRequest, MrStatus, Project, Repository, Review, ReviewComment, ReviewDecision, Task,
+    TaskStatus,
 };
+#[cfg(test)]
+use gyre_domain::{BranchInfo, CommitInfo, DiffResult, MergeResult};
+#[cfg(test)]
+use gyre_ports::GitOpsPort;
 use gyre_ports::{
-    AgentCommitRepository, AgentRepository, GitOpsPort, MergeQueueRepository,
-    MergeRequestRepository, ProjectRepository, RepoRepository, ReviewRepository, TaskRepository,
-    WorktreeRepository,
+    AgentCommitRepository, AgentRepository, MergeQueueRepository, MergeRequestRepository,
+    ProjectRepository, RepoRepository, ReviewRepository, TaskRepository, WorktreeRepository,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// No-op git operations adapter for tests (never touches the filesystem).
+#[cfg(test)]
 #[derive(Default)]
 pub struct NoopGitOps;
 
+#[cfg(test)]
 #[async_trait]
 impl GitOpsPort for NoopGitOps {
     async fn init_bare(&self, _path: &str) -> Result<()> {


### PR DESCRIPTION
## Summary

`NoopGitOps` is only ever constructed inside `test_state()` which is already `#[cfg(test)]`. Without gating the struct itself, `clippy::dead_code` fires and breaks CI.

Changes:
- Gate `NoopGitOps` struct and its `impl GitOpsPort` block with `#[cfg(test)]`
- Move test-only imports to `#[cfg(test)]` use statements:
  - `BranchInfo`, `CommitInfo`, `DiffResult`, `MergeResult` from `gyre_domain`
  - `GitOpsPort` from `gyre_ports`

This is a re-application of the fix from the now-closed PR #8 — the M2.2/M2.3/M2.4 direct-push merges clobbered the previous fix. Now applied fresh against current main including all M2 types.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes  
- [x] `cargo test --all` — 203 tests passing across all crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)