### PR TITLE
docs: update README + AGENTS.md for M2 complete, M3 in progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,9 @@ Key specs to read before making changes:
 | Tech stack + hexagonal invariants | [specs/development/architecture.md](specs/development/architecture.md) |
 | Design principles (invariants) | [specs/system/design-principles.md](specs/system/design-principles.md) |
 | M0 milestone deliverables | [specs/milestones/m0-walking-skeleton.md](specs/milestones/m0-walking-skeleton.md) |
+| M1 milestone deliverables | [specs/milestones/m1-domain-foundation.md](specs/milestones/m1-domain-foundation.md) |
+| M2 milestone deliverables | [specs/milestones/m2-source-control.md](specs/milestones/m2-source-control.md) |
+| M3 milestone deliverables | [specs/milestones/m3-agent-orchestration.md](specs/milestones/m3-agent-orchestration.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |
 

--- a/README.md
+++ b/README.md
@@ -41,15 +41,13 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 
 ## Current Status
 
-**Milestone 0 (Walking Skeleton) - Complete**
+| Milestone | Status | Summary |
+|---|---|---|
+| M0: Walking Skeleton | Done | axum server, SQLite, Svelte SPA, WebSocket, CLI, one Ralph loop |
+| M1: Domain Foundation | Done | 6-entity domain model, full CRUD REST API, Svelte dashboard, agent lifecycle |
+| M2: Source Control | Done | Git forge, MR workflow + reviews, merge queue, agent-commit tracking, worktrees |
+| M3: Agent Orchestration | In Progress | Smart HTTP git, agent spawn API, CLI client, end-to-end Ralph loop |
 
-| Deliverable | Status |
-|---|---|
-| M0.1 Repo Scaffold | Done - Cargo workspace, Nix flake, CI, pre-commit hooks |
-| M0.2 Server Boots | Done - axum HTTP/WS, SQLite, Svelte SPA, OTel tracing |
-| M0.3 CLI Connects | Done - clap CLI, WebSocket client, ratatui TUI |
-| M0.4 One Ralph Loop | Done - Activity log, full Ralph loop with activity trail |
+203 tests passing. Hexagonal architecture enforced mechanically.
 
-26 tests passing. Hexagonal architecture enforced mechanically.
-
-See [`specs/milestones/m0-walking-skeleton.md`](specs/milestones/m0-walking-skeleton.md) for full spec.
+See [`specs/`](specs/index.md) for full specifications.


### PR DESCRIPTION
## Summary

Two documentation gaps detected after M3 spec landed (b8e2648):

**README.md:**
- Previous status table only showed M0 deliverables — M1 and M2 are complete
- Replaced with a concise milestone table: M0/M1/M2 Done, M3 In Progress
- Updated test count from 26 (M0) to 203 (current)
- Updated spec link to point to the full specs index

**AGENTS.md:**
- Architecture Decisions table only had M0 milestone spec link
- Added M1, M2, M3 milestone spec links so agents know where to find the right spec before working

## Test plan

- [ ] Verify README milestone table matches actual project state
- [ ] Verify AGENTS.md spec links resolve to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)