### PR TITLE
fix(cli): cargo fmt + clippy fix for M3.3 CLI code

### DIFF
--- a/crates/gyre-cli/src/client.rs
+++ b/crates/gyre-cli/src/client.rs
@@ -156,10 +156,7 @@ impl GyreClient {
         let body = serde_json::json!({ "status": new_status });
         let resp = self
             .client
-            .put(format!(
-                "{}/api/v1/tasks/{task_id}/status",
-                self.base_url
-            ))
+            .put(format!("{}/api/v1/tasks/{task_id}/status", self.base_url))
             .header("Authorization", self.auth_header())
             .json(&body)
             .send()

--- a/crates/gyre-cli/src/config.rs
+++ b/crates/gyre-cli/src/config.rs
@@ -41,8 +41,7 @@ impl Config {
             std::fs::create_dir_all(parent)?;
         }
         let text = serde_json::to_string_pretty(self)?;
-        std::fs::write(&path, text)
-            .with_context(|| format!("writing {}", path.display()))?;
+        std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
         Ok(())
     }
 

--- a/crates/gyre-cli/src/main.rs
+++ b/crates/gyre-cli/src/main.rs
@@ -190,7 +190,11 @@ async fn main() -> Result<()> {
             tui::run(server, token).await?;
         }
 
-        Commands::Init { server, name, token } => {
+        Commands::Init {
+            server,
+            name,
+            token,
+        } => {
             let api = client::GyreClient::new(server.clone(), token);
             println!("Registering agent '{name}' with {server}...");
             let resp = api.register_agent(&name).await?;
@@ -272,12 +276,13 @@ async fn main() -> Result<()> {
         }
 
         Commands::Mr {
-            command: MrCommands::Create {
-                title,
-                target,
-                repo_id,
-                source,
-            },
+            command:
+                MrCommands::Create {
+                    title,
+                    target,
+                    repo_id,
+                    source,
+                },
         } => {
             let cfg = config::Config::load()?;
             let token = cfg.require_token()?;
@@ -323,7 +328,7 @@ async fn main() -> Result<()> {
             if tasks.is_empty() {
                 println!("No tasks found.");
             } else {
-                println!("{:<20} {:<12} {:<10} {}", "ID", "STATUS", "PRIORITY", "TITLE");
+                println!("{:<20} {:<12} {:<10} TITLE", "ID", "STATUS", "PRIORITY");
                 println!("{}", "-".repeat(70));
                 for t in &tasks {
                     println!(
@@ -442,7 +447,12 @@ mod tests {
             "ralph",
         ]);
         assert!(args.is_ok());
-        if let Commands::Init { server, name, token } = args.unwrap().command {
+        if let Commands::Init {
+            server,
+            name,
+            token,
+        } = args.unwrap().command
+        {
             assert_eq!(server, "http://localhost:3333");
             assert_eq!(name, "ralph");
             assert_eq!(token, DEFAULT_TOKEN);
@@ -465,8 +475,7 @@ mod tests {
 
     #[test]
     fn cli_clone_with_dir_parses() {
-        let args =
-            Cli::try_parse_from(["gyre", "clone", "proj/repo", "--dir", "/tmp/myrepo"]);
+        let args = Cli::try_parse_from(["gyre", "clone", "proj/repo", "--dir", "/tmp/myrepo"]);
         assert!(args.is_ok());
     }
 
@@ -500,12 +509,13 @@ mod tests {
         ]);
         assert!(args.is_ok());
         if let Commands::Mr {
-            command: MrCommands::Create {
-                title,
-                target,
-                repo_id,
-                source,
-            },
+            command:
+                MrCommands::Create {
+                    title,
+                    target,
+                    repo_id,
+                    source,
+                },
         } = args.unwrap().command
         {
             assert_eq!(title, "My PR");


### PR DESCRIPTION
## Summary

M3.3 CLI code was direct-pushed to main without running `cargo fmt` or verifying `cargo clippy`, breaking main CI on the two most recent commits.

**Fixes:**
1. `cargo fmt` on `client.rs`, `config.rs`, `main.rs` — method chain line-wrapping and struct destructure formatting
2. `clippy::literal_with_empty_format_string` in `main.rs:333` — `println!("{:<20} {:<12} {:<10} {}", ..., "TITLE")` simplified to bake `TITLE` into the format string directly

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all` — 255 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)