### PR TITLE
docs: document M4.1 OTel/Prometheus and M4.2 Keycloak JWT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,8 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/git/{project}/{repo}/info/refs` | Smart HTTP git discovery (`?service=git-upload-pack` or `git-receive-pack`) |
 | `POST` | `/git/{project}/{repo}/git-upload-pack` | Smart HTTP git clone / fetch data |
 | `POST` | `/git/{project}/{repo}/git-receive-pack` | Smart HTTP git push data + post-receive hook |
+| `POST` | `/api/v1/auth/api-keys` | Create API key (Admin role required; returns `gyre_<uuid>` key) |
+| `GET` | `/metrics` | Prometheus metrics (request count, duration, active agents, merge queue depth) |
 | `GET` | `/*` | Svelte SPA dashboard (served from `web/dist/`) |
 
 ### Authentication
@@ -145,14 +147,27 @@ All REST and git HTTP endpoints require a Bearer token in the `Authorization` he
 Authorization: Bearer <token>
 ```
 
-Two token types are accepted:
+Four auth mechanisms are accepted (checked in priority order):
 
-| Token source | How to obtain | Scope |
+| Mechanism | How to obtain | Scope |
 |---|---|---|
 | `GYRE_AUTH_TOKEN` env var | Server config (default: `gyre-dev-token`) | Global admin — all endpoints |
 | Per-agent token | Returned by `POST /api/v1/agents` or `POST /api/v1/agents/spawn` | Agent-scoped operations |
+| API key (`gyre_<uuid>`) | `POST /api/v1/auth/api-keys` (Admin only) | Same as the user's role |
+| JWT (Keycloak OIDC) | Keycloak token exchange | Role from `realm_access` JWT claim |
 
-The git HTTP endpoints (`/git/...`) accept both token types so that `gyre clone` / `gyre push` can use the per-agent token stored in `~/.gyre/config`.
+**User roles** (M4.2, populated from Keycloak `realm_access.roles` JWT claim):
+
+| Role | Permissions |
+|---|---|
+| `Admin` | All operations including API key creation and user management |
+| `Developer` | Full CRUD on projects, repos, tasks, MRs |
+| `Agent` | Spawn/complete agent ops, task assignment, git push |
+| `ReadOnly` | GET-only access |
+
+The git HTTP endpoints (`/git/...`) accept all four auth mechanisms so that `gyre clone` / `gyre push` can use the per-agent token stored in `~/.gyre/config`.
+
+> **Note (M4.2):** JWT/OIDC auth is implemented but requires `GYRE_OIDC_ISSUER` env var wiring in `main.rs` to activate in production — see `crates/gyre-server/src/auth.rs`. Until that env var is wired, the server falls back to agent-token auth only.
 
 ### Server Environment Variables
 
@@ -161,6 +176,9 @@ The git HTTP endpoints (`/git/...`) accept both token types so that `gyre clone`
 | `GYRE_PORT` | `3000` | TCP port to listen on |
 | `GYRE_AUTH_TOKEN` | `gyre-dev-token` | Bearer token clients must send to authenticate |
 | `GYRE_DB_PATH` | `gyre.db` | SQLite database file path |
+| `GYRE_BASE_URL` | `http://localhost:<port>` | Public base URL (used in clone URLs returned by spawn API) |
+| `GYRE_LOG_FORMAT` | _(human-readable)_ | Set to `json` for structured JSON log output (M4.1) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(disabled)_ | OTLP/gRPC collector URL, e.g. `http://otel-collector:4317` (M4.1) |
 | `RUST_LOG` | `info` | Log level filter (e.g. `debug`, `gyre_server=trace`) |
 
 ### WebSocket Protocol (`gyre-common::WsMessage`)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M1: Domain Foundation | Done | 6-entity domain model, full CRUD REST API, Svelte dashboard, agent lifecycle |
 | M2: Source Control | Done | Git forge, MR workflow + reviews, merge queue, agent-commit tracking, worktrees |
 | M3: Agent Orchestration | Done | Smart HTTP git, agent spawn API, CLI client, end-to-end Ralph loop |
-| M4: Identity & Observability | Planning | Keycloak SSO, RBAC, OpenTelemetry tracing, admin panel |
+| M4: Identity & Observability | In Progress | Keycloak SSO + JWT auth, RBAC roles, OpenTelemetry tracing, Prometheus metrics |
 
 256 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

Covers documentation gaps from M4.1 and M4.2, both of which landed on main via direct push without AGENTS.md updates.

**M4.1 (OpenTelemetry + Prometheus):**
- Add `GET /metrics` to endpoint table
- Add `GYRE_LOG_FORMAT` env var (json structured logging)
- Add `OTEL_EXPORTER_OTLP_ENDPOINT` env var (OTLP/gRPC collector, optional)
- Add `GYRE_BASE_URL` env var (was missing since M3.4)

**M4.2 (Keycloak SSO + JWT auth):**
- Add `POST /api/v1/auth/api-keys` to endpoint table
- Expand Authentication section: document all 4 auth mechanisms (global token, per-agent token, API key, JWT) in priority order
- Add User roles table (Admin/Developer/Agent/ReadOnly) with Keycloak `realm_access` claim mapping
- Add note that `GYRE_OIDC_ISSUER` env var wiring is still pending in `main.rs` (JWT disabled in production until fixed)

**README.md:** M4 status: Planning → In Progress

## ⚠️ Code gap noted (tracked separately)

`build_state()` in `lib.rs` hardcodes `jwt_config: None` and `main.rs` reads no `GYRE_OIDC_ISSUER`/`GYRE_OIDC_AUDIENCE` env vars. M4.2 Keycloak JWT middleware is fully implemented and tested but unreachable in a running server. CEO has been notified. This docs PR notes the gap but does not fix the code.

## Test plan

- [ ] Docs-only — no Rust code changed
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy` passes
- [ ] Verify endpoint rows match `crates/gyre-server/src/api/mod.rs`
- [ ] Verify env vars match `crates/gyre-server/src/telemetry.rs` and `main.rs`
- [ ] Verify roles match `crates/gyre-domain/src/user.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)