### PR TITLE
fix(server): suppress dead_code lint on rbac::forbidden — restore CI

### DIFF
--- a/crates/gyre-server/src/rbac.rs
+++ b/crates/gyre-server/src/rbac.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use crate::{auth::AuthenticatedAgent, AppState};
 
+#[allow(dead_code)]
 fn forbidden() -> Response {
     (
         StatusCode::FORBIDDEN,


### PR DESCRIPTION
## Summary

Fixes CI break on main caused by M4.3 direct-push (commit 7c60e28).

**Root cause:** `fn forbidden()` in `crates/gyre-server/src/rbac.rs:22` is a private helper called from `RequireDeveloper`, `RequireAgent`, and `RequireReadOnly` extractor impls — but those extractors are not yet wired into any route handlers, so clippy's `dead_code` lint fires on the entire chain including the helper.

**Fix:** Add `#[allow(dead_code)]` to `fn forbidden()`, consistent with the existing `#[allow(dead_code)]` already on the extractor structs above.

This is the same pattern as the `NoopGitOps` dead_code fix in PR #10.

## Test plan

- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)