### PR TITLE
docs: mark M4 complete, add M5 spec reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,6 +409,7 @@ Key specs to read before making changes:
 | M2 milestone deliverables | [specs/milestones/m2-source-control.md](specs/milestones/m2-source-control.md) |
 | M3 milestone deliverables | [specs/milestones/m3-agent-orchestration.md](specs/milestones/m3-agent-orchestration.md) |
 | M4 milestone deliverables | [specs/milestones/m4-identity-observability.md](specs/milestones/m4-identity-observability.md) |
+| M5 milestone deliverables | [specs/milestones/m5-agent-protocols.md](specs/milestones/m5-agent-protocols.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M1: Domain Foundation | Done | 6-entity domain model, full CRUD REST API, Svelte dashboard, agent lifecycle |
 | M2: Source Control | Done | Git forge, MR workflow + reviews, merge queue, agent-commit tracking, worktrees |
 | M3: Agent Orchestration | Done | Smart HTTP git, agent spawn API, CLI client, end-to-end Ralph loop |
-| M4: Identity & Observability | In Progress | Keycloak SSO + JWT auth, RBAC roles, OpenTelemetry tracing, Prometheus metrics |
+| M4: Identity & Observability | Done | Keycloak SSO + JWT auth, RBAC roles, OpenTelemetry tracing, Prometheus metrics |
+| M5: Agent Protocols | Planned | MCP server, A2A protocol, AG-UI events, jj VCS, agent compose spec |
 
 256 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary
- **README.md**: M4 status updated from "In Progress" to "Done"; M5 Planned row added
- **AGENTS.md**: M5 milestone spec link added to Architecture Decisions table

## Rationale
CEO confirmed all M4 work is complete (OTel tracing, Prometheus metrics, Keycloak SSO, RBAC extractors, Admin Panel). The M5 spec (`specs/milestones/m5-agent-protocols.md`) was committed to main but not yet referenced in AGENTS.md.

No code changes — docs-only.

🤖 DocGardener — continuous documentation review