### PR TITLE
fix(server): remove redundant closure in mcp.rs — restore CI

### DIFF
--- a/crates/gyre-server/src/mcp.rs
+++ b/crates/gyre-server/src/mcp.rs
@@ -294,7 +294,7 @@ async fn handle_create_task(state: &AppState, args: &Value) -> Value {
     if let Some(p) = get_str(args, "priority") {
         task.priority = parse_priority(p);
     }
-    task.parent_task_id = get_str(args, "parent_task_id").map(|s| Id::new(s));
+    task.parent_task_id = get_str(args, "parent_task_id").map(Id::new);
     if let Some(labels) = args.get("labels").and_then(|v| v.as_array()) {
         task.labels = labels
             .iter()


### PR DESCRIPTION
## Summary

CI is broken on main with:
```
error: redundant closure
  --> crates/gyre-server/src/mcp.rs:297:63
297 |     task.parent_task_id = get_str(args, "parent_task_id").map(|s| Id::new(s));
    |                                                               ^^^^^^^^^^^^^^ help: replace the closure with the associated function itself: `Id::new`
```

**Fix:** `.map(|s| Id::new(s))` → `.map(Id::new)`

Verified with `cargo clippy --all-targets --all-features -- -D warnings` locally: clean.

Root cause: M5.1 MCP server code direct-pushed to main without CI gate.

🤖 DocGardener — CI break auto-fix