### PR TITLE
docs: mark M5 complete, add M6 Infrastructure spec reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,6 +529,7 @@ Key specs to read before making changes:
 | M3 milestone deliverables | [specs/milestones/m3-agent-orchestration.md](specs/milestones/m3-agent-orchestration.md) |
 | M4 milestone deliverables | [specs/milestones/m4-identity-observability.md](specs/milestones/m4-identity-observability.md) |
 | M5 milestone deliverables | [specs/milestones/m5-agent-protocols.md](specs/milestones/m5-agent-protocols.md) |
+| M6 milestone deliverables | [specs/milestones/m6-infrastructure.md](specs/milestones/m6-infrastructure.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M2: Source Control | Done | Git forge, MR workflow + reviews, merge queue, agent-commit tracking, worktrees |
 | M3: Agent Orchestration | Done | Smart HTTP git, agent spawn API, CLI client, end-to-end Ralph loop |
 | M4: Identity & Observability | Done | Keycloak SSO + JWT auth, RBAC roles, OpenTelemetry tracing, Prometheus metrics |
-| M5: Agent Protocols | Planned | MCP server, A2A protocol, AG-UI events, jj VCS, agent compose spec |
+| M5: Agent Protocols | Done | MCP server, A2A protocol, AG-UI events, jj VCS, agent compose spec, M5 dashboard |
+| M6: Infrastructure & Operations | Planned | Product analytics, cost tracking, BCP snapshot/restore, background job framework |
 
 256 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

Same pattern as PR #20 (M4 done → M5 spec added): the M6 spec was direct-pushed to main without updating the project-status docs.

### Changes

**README.md:**
- M5 status: `Planned` → `Done` (MCP server, A2A, jj VCS, dashboard all shipped)
- M6 `Planned` row added: Product analytics, cost tracking, BCP snapshot/restore, background job framework

**AGENTS.md:**
- M6 spec link added to Architecture Decisions table

No code changes — docs-only.

🤖 DocGardener — continuous documentation review