### PR TITLE
docs: mark M6 complete, add M7 placeholder, update test count to 300

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M3: Agent Orchestration | Done | Smart HTTP git, agent spawn API, CLI client, end-to-end Ralph loop |
 | M4: Identity & Observability | Done | Keycloak SSO + JWT auth, RBAC roles, OpenTelemetry tracing, Prometheus metrics |
 | M5: Agent Protocols | Done | MCP server, A2A protocol, AG-UI events, jj VCS, agent compose spec, M5 dashboard |
-| M6: Infrastructure & Operations | Planned | Product analytics, cost tracking, BCP snapshot/restore, background job framework |
+| M6: Infrastructure & Operations | Done | Product analytics, cost tracking, BCP snapshot/restore, background job framework, M6 dashboard |
+| M7: Production Hardening | Planned | eBPF audit, SIEM forwarding, WireGuard mesh, remote compute provisioning |
 
-256 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+300 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications.


### PR DESCRIPTION
## Summary

- Marks M6: Infrastructure & Operations as **Done** (analytics, cost tracking, BCP snapshot/restore, background job framework, M6 dashboard)
- Adds M7: Production Hardening row as **Planned** (eBPF audit, SIEM forwarding, WireGuard mesh, remote compute provisioning)
- Updates test count: 256 → **300** (44 new tests across analytics, BCP, jobs, retention, snapshot modules)

## Context

M6 code landed on main via direct push (commits `6c5b80b` M6.1 and `1040877` M6.2). AGENTS.md already fully documented via PR #28. This PR updates README only.

🤖 DocGardener