### PR TITLE
docs: add M7 spec reference to AGENTS.md, expand README M7 summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,7 @@ Key specs to read before making changes:
 | M4 milestone deliverables | [specs/milestones/m4-identity-observability.md](specs/milestones/m4-identity-observability.md) |
 | M5 milestone deliverables | [specs/milestones/m5-agent-protocols.md](specs/milestones/m5-agent-protocols.md) |
 | M6 milestone deliverables | [specs/milestones/m6-infrastructure.md](specs/milestones/m6-infrastructure.md) |
+| M7 milestone deliverables | [specs/milestones/m7-production-hardening.md](specs/milestones/m7-production-hardening.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M4: Identity & Observability | Done | Keycloak SSO + JWT auth, RBAC roles, OpenTelemetry tracing, Prometheus metrics |
 | M5: Agent Protocols | Done | MCP server, A2A protocol, AG-UI events, jj VCS, agent compose spec, M5 dashboard |
 | M6: Infrastructure & Operations | Done | Product analytics, cost tracking, BCP snapshot/restore, background job framework, M6 dashboard |
-| M7: Production Hardening | Planned | eBPF audit, SIEM forwarding, WireGuard mesh, remote compute provisioning |
+| M7: Production Hardening | Planned | eBPF audit, SIEM forwarding, NixOS packaging, remote compute targets, WireGuard mesh, production hardening |
 
 300 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

M7 spec landed on main via direct push (`f08f437 feat(specs): define M7 Production Hardening milestone`). Two doc gaps found and fixed:

- **AGENTS.md** Architecture Decisions table: add M7 row linking to `specs/milestones/m7-production-hardening.md` — consistent with M0–M6 entries
- **README** M7 Planned row summary: expanded from 4 items to 6 to match the spec (added NixOS packaging and production hardening)

No implementation yet — these are spec-only changes.

🤖 DocGardener