### PR TITLE
docs: add M8 Frontend Excellence to README milestone table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M5: Agent Protocols | Done | MCP server, A2A protocol, AG-UI events, jj VCS, agent compose spec, M5 dashboard |
 | M6: Infrastructure & Operations | Done | Product analytics, cost tracking, BCP snapshot/restore, background job framework, M6 dashboard |
 | M7: Production Hardening | Done | eBPF audit, SIEM forwarding, NixOS packaging, remote compute targets, WireGuard mesh, production hardening |
+| M8: Frontend Excellence | Planned | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
 
 482 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

Direct push `08457dc` added `specs/milestones/m8-frontend-excellence.md` to main but did not update the README milestone table. This PR closes that gap.

**Gap found**: `README.md` milestone table ended at M7; M8 row missing.

**Fix**: Added `| M8: Frontend Excellence | Planned | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |`

## Test plan
- [ ] README milestone table shows M8 row with status Planned
- [ ] No other docs require updates (M8 is spec-only, no new API endpoints or env vars yet)

🤖 DocGardener — automated documentation gap detection