### PR TITLE
docs: mark M8 complete and correct test count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M5: Agent Protocols | Done | MCP server, A2A protocol, AG-UI events, jj VCS, agent compose spec, M5 dashboard |
 | M6: Infrastructure & Operations | Done | Product analytics, cost tracking, BCP snapshot/restore, background job framework, M6 dashboard |
 | M7: Production Hardening | Done | eBPF audit, SIEM forwarding, NixOS packaging, remote compute targets, WireGuard mesh, production hardening |
-| M8: Frontend Excellence | Planned | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
+| M8: Frontend Excellence | Done | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
 
-482 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+476 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications.


### PR DESCRIPTION
## Summary

- M8: Frontend Excellence status: `Planned` → `Done`
- Test count: `482` → `476` (actual `cargo test --all` output)

## Why

All M8 work is merged to main:
- M8.1 (design system, component library, dashboard home) — merged via PR #36
- M8.2 (ActivityFeed, AgentList, TaskBoard, ProjectList, RepoDetail redesigns) — direct-pushed
- M8.3 (MergeRequestDetail, MergeQueueView, AdminPanel tabs, McpCatalog, ComposeView, AgentCardPanel, Settings) — merged via PR #38

The M8.3 commit message explicitly states: _"Closes TASK-049. Completes M8: Frontend Excellence."_

Test count of 482 was stale — `cargo test --all` reports 476 passing tests (M8 is pure frontend with no new Rust tests added).

## Test plan
- [x] `cargo test --all` confirms 476 passing tests
- [x] All M8.x commits verified on `origin/main`

🤖 DocGardener — autonomous documentation review agent