### PR TITLE
docs: add M9-M12 milestones and auth token UI to README + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,7 @@ Access at `http://localhost:3000` after starting the server. Admin Panel require
 - **Merge Request Detail** (M8.3): two-column layout — diff panel left, metadata + status timeline right. Status timeline shows each MR lifecycle step with timestamps and reviewer info.
 - **Merge Queue View** (M8.3): visual flow lanes per queue position with progress bars, estimated wait indicators, and per-entry action buttons (cancel).
 - **Settings** (M8.3): server info card (name, version, milestone fetched from `/api/v1/version`), pulsing WebSocket connection indicator (connected / connecting / disconnected / error with semantic colors), configuration reference table, Gyre branding card.
+- **Auth Token UI** (M9.3): auth status dot in topbar (green = authenticated, red = error). Click opens Token modal to view/change the API token stored in `localStorage`; saving reconnects the WebSocket. All REST and MCP calls inject `Authorization: Bearer {token}`. Defaults to `gyre-dev-token` when no token is stored.
 
 ---
 
@@ -579,6 +580,10 @@ Key specs to read before making changes:
 | M6 milestone deliverables | [specs/milestones/m6-infrastructure.md](specs/milestones/m6-infrastructure.md) |
 | M7 milestone deliverables | [specs/milestones/m7-production-hardening.md](specs/milestones/m7-production-hardening.md) |
 | M8 milestone deliverables | [specs/milestones/m8-frontend-excellence.md](specs/milestones/m8-frontend-excellence.md) |
+| M9 milestone deliverables | [specs/milestones/m9-functional-ui.md](specs/milestones/m9-functional-ui.md) |
+| M10 milestone deliverables | [specs/milestones/m10-persistent-storage.md](specs/milestones/m10-persistent-storage.md) |
+| M11 milestone deliverables | [specs/milestones/m11-agent-execution.md](specs/milestones/m11-agent-execution.md) |
+| M12 milestone deliverables | [specs/milestones/m12-quality-gates.md](specs/milestones/m12-quality-gates.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M6: Infrastructure & Operations | Done | Product analytics, cost tracking, BCP snapshot/restore, background job framework, M6 dashboard |
 | M7: Production Hardening | Done | eBPF audit, SIEM forwarding, NixOS packaging, remote compute targets, WireGuard mesh, production hardening |
 | M8: Frontend Excellence | Done | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
+| M9: Functional UI | In Progress | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
+| M10: Persistent Storage | Planned | SQLite persistence, real-time WebSocket events, git repo management |
+| M11: Agent Execution | Planned | Real agent processes, TTY attach, agent logs, execution lifecycle |
+| M12: Quality Gates | Planned | Merge queue gates, repo mirroring, diff viewer |
 
 476 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

**README:**
- Adds M9: Functional UI row (In Progress) — seed data endpoint, CRUD modals, auth token integration
- Adds M10-M12 placeholder rows (Planned) — specs exist via PR #43

**AGENTS.md:**
- Adds **Auth Token UI** (M9.3) bullet to Dashboard section: topbar status dot, Token modal, `localStorage` token storage, `Authorization: Bearer {token}` injection into all REST and MCP calls. Defaults to `gyre-dev-token`.
- Adds M9-M12 spec links to the Architecture Decisions table

## Why

PRs #42 (`feat(web): add auth token integration to frontend`) and #43 (`feat(specs): define M9-M12 milestone specs`) both merged to main without AGENTS.md or README updates:
- README still ended at M8 with no mention of M9 or beyond
- AGENTS.md had no Auth Token UI documentation despite `App.svelte` gaining a topbar token indicator + modal
- Architecture Decisions table had no M9-M12 spec links

## Test plan
- [x] README milestone table has M9 (In Progress) and M10-M12 (Planned) rows
- [x] AGENTS.md Dashboard section has Auth Token UI bullet
- [x] AGENTS.md Architecture Decisions table links to all 4 new specs

🤖 DocGardener — autonomous documentation review agent