### PR TITLE
style(server): fix cargo fmt in seed endpoint — restore CI green

### DIFF
--- a/crates/gyre-server/src/api/admin.rs
+++ b/crates/gyre-server/src/api/admin.rs
@@ -460,9 +460,17 @@ pub async fn admin_seed(
     state.agents.create(&agent4).await?;
 
     // ── Tasks ─────────────────────────────────────────────────────────────────
-    let task1 = Task::new(Id::new("seed-task-1"), "Set up NixOS flake for CI", now - 3000);
+    let task1 = Task::new(
+        Id::new("seed-task-1"),
+        "Set up NixOS flake for CI",
+        now - 3000,
+    );
 
-    let mut task2 = Task::new(Id::new("seed-task-2"), "Implement agent spawn API", now - 2800);
+    let mut task2 = Task::new(
+        Id::new("seed-task-2"),
+        "Implement agent spawn API",
+        now - 2800,
+    );
     task2.status = TaskStatus::InProgress;
     task2.priority = TaskPriority::High;
     task2.assigned_to = Some(Id::new("seed-agent-1"));
@@ -482,7 +490,11 @@ pub async fn admin_seed(
     );
     task4.status = TaskStatus::Review;
 
-    let mut task5 = Task::new(Id::new("seed-task-5"), "Write E2E Ralph loop test", now - 5000);
+    let mut task5 = Task::new(
+        Id::new("seed-task-5"),
+        "Write E2E Ralph loop test",
+        now - 5000,
+    );
     task5.status = TaskStatus::Done;
     task5.priority = TaskPriority::Critical;
 
@@ -522,12 +534,8 @@ pub async fn admin_seed(
     state.merge_requests.create(&mr_merged).await?;
 
     // ── Merge Queue ───────────────────────────────────────────────────────────
-    let queue_entry = MergeQueueEntry::new(
-        Id::new("seed-queue-1"),
-        Id::new("seed-mr-1"),
-        50,
-        now - 600,
-    );
+    let queue_entry =
+        MergeQueueEntry::new(Id::new("seed-queue-1"), Id::new("seed-mr-1"), 50, now - 600);
     state.merge_queue.enqueue(&queue_entry).await?;
 
     // ── Activity Events ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Runs `cargo fmt` on `crates/gyre-server/src/api/admin.rs` to fix formatting introduced by the direct-pushed seed endpoint commit `04532ac`.

## Why

`04532ac` (`feat(server): add POST /api/v1/admin/seed endpoint for demo data`) was pushed directly to main with long lines that `cargo fmt` reformats. This breaks `cargo fmt --check` in CI for all PRs targeting main, including DocGardener's open PR #46.

## Test plan
- [x] `cargo fmt --all -- --check` exits 0
- [x] No logic changes — formatting only

🤖 DocGardener — CI fix