### PR TITLE
feat(server): M10.2 real-time domain event broadcasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "prometheus",
  "reqwest",
  "ring",
+ "rusqlite",
  "rust-embed",
  "serde",
  "serde_json",

--- a/crates/gyre-server/Cargo.toml
+++ b/crates/gyre-server/Cargo.toml
@@ -40,6 +40,7 @@ uuid = { workspace = true }
 jsonwebtoken = { workspace = true }
 reqwest = { workspace = true }
 serde_yaml = { workspace = true }
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 tokio-tungstenite = "0.24"

--- a/crates/gyre-server/src/api/agents.rs
+++ b/crates/gyre-server/src/api/agents.rs
@@ -8,6 +8,7 @@ use gyre_domain::{Agent, AgentStatus};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use crate::domain_events::DomainEvent;
 use crate::AppState;
 
 use super::error::ApiError;
@@ -81,6 +82,7 @@ pub async fn create_agent(
     let mut agent = Agent::new(new_id(), req.name, now);
     agent.parent_id = req.parent_id.map(Id::new);
     state.agents.create(&agent).await?;
+    let _ = state.event_tx.send(DomainEvent::AgentCreated { id: agent.id.to_string() });
 
     let token = uuid::Uuid::new_v4().to_string();
     state
@@ -138,6 +140,10 @@ pub async fn update_agent_status(
         .transition_status(new_status)
         .map_err(|e| ApiError::InvalidInput(e.to_string()))?;
     state.agents.update(&agent).await?;
+    let _ = state.event_tx.send(DomainEvent::AgentStatusChanged {
+        id: agent.id.to_string(),
+        status: req.status.clone(),
+    });
     Ok(Json(AgentResponse::from(agent)))
 }
 

--- a/crates/gyre-server/src/api/merge_requests.rs
+++ b/crates/gyre-server/src/api/merge_requests.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::instrument;
 
+use crate::domain_events::DomainEvent;
 use crate::AppState;
 
 use super::error::ApiError;
@@ -240,6 +241,7 @@ pub async fn create_mr(
     }
 
     state.merge_requests.create(&mr).await?;
+    let _ = state.event_tx.send(DomainEvent::MrCreated { id: mr.id.to_string() });
     Ok((StatusCode::CREATED, Json(MrResponse::from(mr))))
 }
 
@@ -288,6 +290,10 @@ pub async fn transition_mr_status(
     let ts = now_secs();
     mr.updated_at = ts;
     state.merge_requests.update(&mr).await?;
+    let _ = state.event_tx.send(DomainEvent::MrStatusChanged {
+        id: mr.id.to_string(),
+        status: req.status.clone(),
+    });
 
     // Auto-track mr.merged analytics event
     if is_merge {

--- a/crates/gyre-server/src/api/tasks.rs
+++ b/crates/gyre-server/src/api/tasks.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::instrument;
 
+use crate::domain_events::DomainEvent;
 use crate::AppState;
 
 use super::error::ApiError;
@@ -136,6 +137,7 @@ pub async fn create_task(
     task.parent_task_id = req.parent_task_id.map(Id::new);
     task.labels = req.labels.unwrap_or_default();
     state.tasks.create(&task).await?;
+    let _ = state.event_tx.send(DomainEvent::TaskCreated { id: task.id.to_string() });
     Ok((StatusCode::CREATED, Json(TaskResponse::from(task))))
 }
 
@@ -220,6 +222,10 @@ pub async fn transition_task_status(
     let ts = now_secs();
     task.updated_at = ts;
     state.tasks.update(&task).await?;
+    let _ = state.event_tx.send(DomainEvent::TaskTransitioned {
+        id: task.id.to_string(),
+        status: req.status.clone(),
+    });
 
     // Auto-track status transition as analytics event
     let event = AnalyticsEvent::new(

--- a/crates/gyre-server/src/domain_events.rs
+++ b/crates/gyre-server/src/domain_events.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+/// Domain events broadcast over the event bus to all connected WebSocket clients.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "event")]
+pub enum DomainEvent {
+    AgentCreated { id: String },
+    AgentStatusChanged { id: String, status: String },
+    TaskCreated { id: String },
+    TaskTransitioned { id: String, status: String },
+    MrCreated { id: String },
+    MrStatusChanged { id: String, status: String },
+    ActivityRecorded { id: String, event_type: String },
+    QueueUpdated,
+    DataSeeded,
+}

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -2,6 +2,7 @@ pub(crate) mod activity;
 pub mod api;
 pub mod audit_simulator;
 pub(crate) mod auth;
+pub mod domain_events;
 pub(crate) mod git_http;
 pub(crate) mod health;
 pub mod jobs;
@@ -30,6 +31,7 @@ use gyre_ports::{
     NetworkPeerRepository, ProjectRepository, RepoRepository, ReviewRepository, TaskRepository,
     UserRepository, WorktreeRepository,
 };
+use domain_events::DomainEvent;
 use jobs::JobRegistry;
 use messages::AgentMessage;
 use retention::RetentionStore;
@@ -83,6 +85,8 @@ pub struct AppState {
     pub worktrees: Arc<dyn WorktreeRepository>,
     pub activity_store: activity::ActivityStore,
     pub broadcast_tx: broadcast::Sender<ActivityEventData>,
+    /// Domain event bus: broadcasts structured domain events to all WS clients.
+    pub event_tx: broadcast::Sender<DomainEvent>,
     /// Per-agent message inboxes: agent_id -> queued messages.
     pub agent_messages: Arc<Mutex<HashMap<String, VecDeque<AgentMessage>>>>,
     /// Auth tokens issued on agent registration: agent_id -> token.
@@ -210,6 +214,7 @@ pub fn build_state(
     jwt_config: Option<Arc<JwtConfig>>,
 ) -> Arc<AppState> {
     let (broadcast_tx, _) = broadcast::channel(256);
+    let (event_tx, _) = broadcast::channel(256);
     let (audit_broadcast_tx, _) = broadcast::channel(1024);
     let metrics = Arc::new(metrics::Metrics::new().expect("failed to create Prometheus metrics"));
     let started_at_secs = std::time::SystemTime::now()
@@ -236,6 +241,7 @@ pub fn build_state(
         worktrees: Arc::new(mem::MemWorktreeRepository::default()),
         activity_store: activity::ActivityStore::new(),
         broadcast_tx,
+        event_tx,
         agent_messages: Arc::new(Mutex::new(HashMap::new())),
         agent_tokens: Arc::new(Mutex::new(HashMap::new())),
         users: Arc::new(mem::MemUserRepository::default()),

--- a/crates/gyre-server/src/middleware.rs
+++ b/crates/gyre-server/src/middleware.rs
@@ -139,6 +139,7 @@ mod tests {
             audit_broadcast_tx: base.audit_broadcast_tx.clone(),
             compute_targets: base.compute_targets.clone(),
             network_peers: base.network_peers.clone(),
+            event_tx: base.event_tx.clone(),
         });
         crate::build_router(state)
     }

--- a/crates/gyre-server/src/ws.rs
+++ b/crates/gyre-server/src/ws.rs
@@ -7,10 +7,21 @@ use axum::{
 };
 use futures_util::{SinkExt, StreamExt};
 use gyre_common::{ActivityEventData, WsMessage};
+use serde::Serialize;
 use std::sync::Arc;
 use tracing::{info, instrument, warn};
 
+use crate::domain_events::DomainEvent;
 use crate::AppState;
+
+/// Wrapper that adds `type: "DomainEvent"` to the serialized domain event.
+#[derive(Serialize)]
+struct WsDomainEvent<'a> {
+    #[serde(rename = "type")]
+    msg_type: &'static str,
+    #[serde(flatten)]
+    event: &'a DomainEvent,
+}
 
 /// GET /ws - WebSocket upgrade endpoint.
 pub async fn ws_handler(
@@ -43,6 +54,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
     }
 
     let mut broadcast_rx = state.broadcast_tx.subscribe();
+    let mut domain_event_rx = state.event_tx.subscribe();
 
     // Main message loop: handle activity messages and broadcast events.
     loop {
@@ -118,6 +130,21 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         warn!(n, "broadcast receiver lagged");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            domain_ev = domain_event_rx.recv() => {
+                match domain_ev {
+                    Ok(event) => {
+                        let wrapper = WsDomainEvent { msg_type: "DomainEvent", event: &event };
+                        let payload = serde_json::to_string(&wrapper).unwrap();
+                        if sender.send(Message::Text(payload)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(n, "domain event receiver lagged");
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }
@@ -366,6 +393,31 @@ mod tests {
             } else {
                 panic!("expected ActivityEvent, got: {:?}", result);
             }
+        } else {
+            panic!("expected text message");
+        }
+    }
+
+    #[tokio::test]
+    async fn ws_domain_event_broadcast_to_client() {
+        let (url, state) = start_test_server("tok").await;
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+        auth_ws(&mut ws, "tok").await;
+
+        // Publish a domain event via the event bus.
+        let _ = state
+            .event_tx
+            .send(crate::domain_events::DomainEvent::AgentCreated {
+                id: "agent-123".to_string(),
+            });
+
+        // Client should receive a DomainEvent message.
+        let msg = ws.next().await.unwrap().unwrap();
+        if let tungstenite::Message::Text(text) = msg {
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(value["type"], "DomainEvent");
+            assert_eq!(value["event"], "AgentCreated");
+            assert_eq!(value["id"], "agent-123");
         } else {
             panic!("expected text message");
         }


### PR DESCRIPTION
## Summary
- DomainEvent enum with 9 event types (AgentCreated, TaskCreated, etc.)
- tokio::broadcast event bus on AppState
- WebSocket handler subscribes and forwards domain events to all connected clients
- API handlers publish events on agent/task/MR mutations
- 1 new test verifying end-to-end WebSocket event delivery

## Test plan
- [x] `cargo test -p gyre-server --lib` — 256 pass
- [x] `cargo clippy` — clean
- [x] New test: `ws_domain_event_broadcast_to_client`

Generated with [Claude Code](https://claude.com/claude-code)