### PR TITLE
docs: update M10 status, test count, and GYRE_REPOS_PATH env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ The git HTTP endpoints (`/git/...`) accept all four auth mechanisms so that `gyr
 | `GYRE_CORS_ORIGINS` | `*` | Comma-separated allowed CORS origins; `*` allows all (M7.3) |
 | `GYRE_RATE_LIMIT` | `100` | Requests per second allowed per IP before 429 (M7.3) |
 | `GYRE_AUDIT_SIMULATE` | _(disabled)_ | Set to `true` to run the audit event simulator on startup (M7.1) |
+| `GYRE_REPOS_PATH` | `./repos/` | Directory for bare git repositories on disk. Created on startup if absent. (M10.3) |
 
 ### WebSocket Protocol (`gyre-common::WsMessage`)
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M7: Production Hardening | Done | eBPF audit, SIEM forwarding, NixOS packaging, remote compute targets, WireGuard mesh, production hardening |
 | M8: Frontend Excellence | Done | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
 | M9: Functional UI | In Progress | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
-| M10: Persistent Storage | Planned | SQLite persistence, real-time WebSocket events, git repo management |
+| M10: Persistent Storage | In Progress | SQLite persistence, real-time WebSocket events, git repo management |
 | M11: Agent Execution | Planned | Real agent processes, TTY attach, agent logs, execution lifecycle |
 | M12: Quality Gates | Planned | Merge queue gates, repo mirroring, diff viewer |
 
-476 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+480 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications.


### PR DESCRIPTION
## Summary

Documentation gaps from M10.2 (#50) and M10.3 (#49) merges:

- Mark **M10: Persistent Storage** as `In Progress` (M10.2 WebSocket broadcasting + M10.3 git repo storage both landed)
- Update test count **476 → 480**
- Add **`GYRE_REPOS_PATH`** to the server environment variables table in AGENTS.md

## Changes

- `README.md`: M10 status Planned → In Progress, 476 → 480 tests
- `AGENTS.md`: Add `GYRE_REPOS_PATH` env var row (default `./repos/`, created on startup, M10.3)

🤖 DocGardener — automated doc gap fix