### PR TITLE
style: run cargo fmt on M10.2+M10.3 code — restore CI green

### DIFF
--- a/crates/gyre-adapters/src/git2_ops.rs
+++ b/crates/gyre-adapters/src/git2_ops.rs
@@ -349,14 +349,8 @@ impl GitOpsPort for Git2OpsAdapter {
             let tree_oid = builder.write()?;
             let tree = repo.find_tree(tree_oid)?;
             let refname = format!("refs/heads/{branch}");
-            let commit_oid = repo.commit(
-                Some(&refname),
-                &sig,
-                &sig,
-                "Initial commit",
-                &tree,
-                &[],
-            )?;
+            let commit_oid =
+                repo.commit(Some(&refname), &sig, &sig, "Initial commit", &tree, &[])?;
             repo.set_head(&refname)?;
             Ok(commit_oid.to_string())
         })
@@ -447,10 +441,7 @@ mod tests {
             .await
             .unwrap();
 
-        let branches = adapter
-            .list_branches(path.to_str().unwrap())
-            .await
-            .unwrap();
+        let branches = adapter.list_branches(path.to_str().unwrap()).await.unwrap();
         assert_eq!(branches.len(), 1);
         assert_eq!(branches[0].name, "main");
         assert!(branches[0].is_default);

--- a/crates/gyre-server/src/api/admin.rs
+++ b/crates/gyre-server/src/api/admin.rs
@@ -448,10 +448,7 @@ pub async fn admin_seed(
             .create_initial_commit(&repo.path, &repo.default_branch)
             .await
         {
-            tracing::warn!(
-                "seed: create_initial_commit failed for {}: {e}",
-                repo.path
-            );
+            tracing::warn!("seed: create_initial_commit failed for {}: {e}", repo.path);
         }
     }
 
@@ -601,7 +598,6 @@ pub async fn admin_seed(
             timestamp,
         });
     }
-
 
     Ok(Json(SeedResponse {
         projects: 2,

--- a/crates/gyre-server/src/api/agents.rs
+++ b/crates/gyre-server/src/api/agents.rs
@@ -82,7 +82,9 @@ pub async fn create_agent(
     let mut agent = Agent::new(new_id(), req.name, now);
     agent.parent_id = req.parent_id.map(Id::new);
     state.agents.create(&agent).await?;
-    let _ = state.event_tx.send(DomainEvent::AgentCreated { id: agent.id.to_string() });
+    let _ = state.event_tx.send(DomainEvent::AgentCreated {
+        id: agent.id.to_string(),
+    });
 
     let token = uuid::Uuid::new_v4().to_string();
     state

--- a/crates/gyre-server/src/api/merge_requests.rs
+++ b/crates/gyre-server/src/api/merge_requests.rs
@@ -241,7 +241,9 @@ pub async fn create_mr(
     }
 
     state.merge_requests.create(&mr).await?;
-    let _ = state.event_tx.send(DomainEvent::MrCreated { id: mr.id.to_string() });
+    let _ = state.event_tx.send(DomainEvent::MrCreated {
+        id: mr.id.to_string(),
+    });
     Ok((StatusCode::CREATED, Json(MrResponse::from(mr))))
 }
 

--- a/crates/gyre-server/src/api/tasks.rs
+++ b/crates/gyre-server/src/api/tasks.rs
@@ -137,7 +137,9 @@ pub async fn create_task(
     task.parent_task_id = req.parent_task_id.map(Id::new);
     task.labels = req.labels.unwrap_or_default();
     state.tasks.create(&task).await?;
-    let _ = state.event_tx.send(DomainEvent::TaskCreated { id: task.id.to_string() });
+    let _ = state.event_tx.send(DomainEvent::TaskCreated {
+        id: task.id.to_string(),
+    });
     Ok((StatusCode::CREATED, Json(TaskResponse::from(task))))
 }
 

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -23,6 +23,7 @@ pub mod telemetry;
 pub(crate) mod ws;
 
 use axum::{routing::get, Router};
+use domain_events::DomainEvent;
 use gyre_common::ActivityEventData;
 use gyre_domain::AgentCard;
 use gyre_ports::{
@@ -31,7 +32,6 @@ use gyre_ports::{
     NetworkPeerRepository, ProjectRepository, RepoRepository, ReviewRepository, TaskRepository,
     UserRepository, WorktreeRepository,
 };
-use domain_events::DomainEvent;
 use jobs::JobRegistry;
 use messages::AgentMessage;
 use retention::RetentionStore;

--- a/crates/gyre-server/src/main.rs
+++ b/crates/gyre-server/src/main.rs
@@ -30,8 +30,7 @@ async fn main() -> Result<()> {
     });
 
     // Ensure the git repos root directory exists on startup.
-    let repos_dir =
-        std::env::var("GYRE_REPOS_PATH").unwrap_or_else(|_| "./repos".to_string());
+    let repos_dir = std::env::var("GYRE_REPOS_PATH").unwrap_or_else(|_| "./repos".to_string());
     if let Err(e) = std::fs::create_dir_all(&repos_dir) {
         tracing::warn!("failed to create repos directory '{repos_dir}': {e}");
     }


### PR DESCRIPTION
## Summary

- M10.2 (#50) and M10.3 (#49) landed on main with formatting that fails `cargo fmt --check`
- This breaks CI for all open PRs (including the doc fix #51)
- Applies `cargo fmt --all` to restore CI green

## Affected files

- `crates/gyre-adapters/src/git2_ops.rs`
- `crates/gyre-server/src/api/admin.rs`
- `crates/gyre-server/src/api/agents.rs`
- `crates/gyre-server/src/api/merge_requests.rs`
- `crates/gyre-server/src/api/tasks.rs`
- `crates/gyre-server/src/lib.rs`
- `crates/gyre-server/src/main.rs`

🤖 DocGardener — urgent CI fix (same pattern as #47)