### PR TITLE
docs(agents): document M10.2 DomainEvent WebSocket server-push protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,10 +255,23 @@ See `crates/gyre-common/src/protocol.rs` for the full type definitions.
 // 4. Query activity log over WebSocket:
 {"type":"ActivityQuery","since":1234567800,"limit":50}
 {"type":"ActivityResponse","events":[...]}
+
+// 5. Domain event push (server → client, M10.2) — emitted automatically on mutations:
+{"type":"DomainEvent","event":"AgentCreated","id":"<uuid>"}
+{"type":"DomainEvent","event":"AgentStatusChanged","id":"<uuid>","status":"Active"}
+{"type":"DomainEvent","event":"TaskCreated","id":"<uuid>"}
+{"type":"DomainEvent","event":"TaskTransitioned","id":"<uuid>","status":"in_progress"}
+{"type":"DomainEvent","event":"MrCreated","id":"<uuid>"}
+{"type":"DomainEvent","event":"MrStatusChanged","id":"<uuid>","status":"merged"}
+{"type":"DomainEvent","event":"ActivityRecorded","id":"<uuid>","event_type":"RUN_STARTED"}
+{"type":"DomainEvent","event":"QueueUpdated"}
+{"type":"DomainEvent","event":"DataSeeded"}
 ```
 
 The in-memory `ActivityStore` holds up to 1000 events (oldest dropped when full).
 The same events are also queryable via `GET /api/v1/activity?since=<ts>&limit=<n>`.
+
+**Domain events (M10.2):** After authenticating, clients receive server-push `DomainEvent` frames whenever agents, tasks, or MRs are mutated via REST. No client request needed — the server broadcasts to all connected sessions automatically. See `crates/gyre-server/src/domain_events.rs` for the full enum.
 
 #### AG-UI Event Taxonomy (`gyre-common::AgEventType`)
 


### PR DESCRIPTION
## Summary

PR #50 (M10.2 real-time domain event broadcasting) introduced a new server-push message type over WebSocket that was not documented in AGENTS.md.

After authenticating, all WS clients now automatically receive \`DomainEvent\` frames when agents/tasks/MRs are mutated via REST — no client request needed.

## Gap fixed

Added to the **WebSocket Protocol** section:
- 9 example \`DomainEvent\` JSON frames (one per variant: AgentCreated, AgentStatusChanged, TaskCreated, TaskTransitioned, MrCreated, MrStatusChanged, ActivityRecorded, QueueUpdated, DataSeeded)
- Prose description explaining the broadcast behaviour and pointer to \`domain_events.rs\`

## No code changes — docs only

🤖 DocGardener — doc gap from merged PR #50