### PR TITLE
docs: mark M10 complete, 484 tests, add GYRE_DATABASE_URL env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,7 @@ The git HTTP endpoints (`/git/...`) accept all four auth mechanisms so that `gyr
 | `GYRE_RATE_LIMIT` | `100` | Requests per second allowed per IP before 429 (M7.3) |
 | `GYRE_AUDIT_SIMULATE` | _(disabled)_ | Set to `true` to run the audit event simulator on startup (M7.1) |
 | `GYRE_REPOS_PATH` | `./repos/` | Directory for bare git repositories on disk. Created on startup if absent. (M10.3) |
+| `GYRE_DATABASE_URL` | _(unset — in-memory)_ | SQLite database URL, e.g. `sqlite://gyre.db`. When set, all 16 port traits persist to SQLite with WAL mode. Unset = in-memory (default, stateless). (M10.1) |
 
 ### WebSocket Protocol (`gyre-common::WsMessage`)
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M7: Production Hardening | Done | eBPF audit, SIEM forwarding, NixOS packaging, remote compute targets, WireGuard mesh, production hardening |
 | M8: Frontend Excellence | Done | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
 | M9: Functional UI | In Progress | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
-| M10: Persistent Storage | In Progress | SQLite persistence, real-time WebSocket events, git repo management |
+| M10: Persistent Storage | Done | SQLite persistence, real-time WebSocket events, git repo management |
 | M11: Agent Execution | Planned | Real agent processes, TTY attach, agent logs, execution lifecycle |
 | M12: Quality Gates | Planned | Merge queue gates, repo mirroring, diff viewer |
 
-480 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+484 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications.


### PR DESCRIPTION
## Summary

PR #54 (M10.1 SQLite persistence) completed the final M10 deliverable. All three M10 items have now shipped:
- M10.1: SQLite persistence via `GYRE_DATABASE_URL` (#54)
- M10.2: Real-time WebSocket domain events (#50)
- M10.3: Git repo storage on disk (#49)

## Gaps fixed

- **README**: M10 Persistent Storage `In Progress` → `Done`
- **README**: test count `480` → `484` (5 new SQLite-specific tests in #54)
- **AGENTS.md**: Add `GYRE_DATABASE_URL` to server environment variables table

```
| GYRE_DATABASE_URL | (unset — in-memory) | SQLite database URL, e.g. sqlite://gyre.db.
  When set, all 16 port traits persist to SQLite with WAL mode.
  Unset = in-memory (default, stateless). (M10.1) |
```

🤖 DocGardener — doc gap from merged PR #54