### PR TITLE
docs: mark M9 Functional UI as Done in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M6: Infrastructure & Operations | Done | Product analytics, cost tracking, BCP snapshot/restore, background job framework, M6 dashboard |
 | M7: Production Hardening | Done | eBPF audit, SIEM forwarding, NixOS packaging, remote compute targets, WireGuard mesh, production hardening |
 | M8: Frontend Excellence | Done | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
-| M9: Functional UI | In Progress | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
+| M9: Functional UI | Done | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
 | M10: Persistent Storage | Done | SQLite persistence, real-time WebSocket events, git repo management |
 | M11: Agent Execution | Planned | Real agent processes, TTY attach, agent logs, execution lifecycle |
 | M12: Quality Gates | Planned | Merge queue gates, repo mirroring, diff viewer |


### PR DESCRIPTION
## Summary

README shows M9 as `In Progress` but all three deliverables have shipped:

| Deliverable | PR | Status |
|---|---|---|
| M9.1 — `POST /api/v1/admin/seed` idempotent demo data | #45 content (merged direct) | ✅ |
| M9.2 — CRUD modals (Projects, Repos, Tasks) + quick actions | #44 | ✅ |
| M9.3 — Auth token UI, localStorage, Bearer injection, WS reconnect | #42 | ✅ |

Verified against `specs/milestones/m9-functional-ui.md` — all three M9.x sections fully implemented.

## Change

- `README.md`: M9 `In Progress` → `Done`

🤖 DocGardener — stale milestone status detected in routine docs audit