### PR TITLE
feat(server): M11.1 wire spawn API to real agent processes

### DIFF
--- a/crates/gyre-server/src/api/admin.rs
+++ b/crates/gyre-server/src/api/admin.rs
@@ -285,6 +285,16 @@ pub async fn admin_kill_agent(
     let _ = agent.transition_status(AgentStatus::Dead);
     state.agents.update(&agent).await?;
 
+    // Kill the actual process if it is running.
+    if let Some(handle) = state.process_registry.lock().await.remove(&id) {
+        if let Err(e) =
+            gyre_ports::ComputeTarget::kill_process(&gyre_adapters::compute::LocalTarget, &handle)
+                .await
+        {
+            tracing::warn!(agent_id = %id, "kill_process failed: {e}");
+        }
+    }
+
     // Clean up worktrees.
     if let Ok(worktrees) = state.worktrees.find_by_agent(&agent.id).await {
         for wt in worktrees {

--- a/crates/gyre-server/src/api/spawn.rs
+++ b/crates/gyre-server/src/api/spawn.rs
@@ -27,6 +27,10 @@ pub struct SpawnAgentRequest {
     pub parent_id: Option<String>,
     /// Optional compute target to associate with this agent spawn.
     pub compute_target_id: Option<String>,
+    /// Command to execute in the spawned process. Defaults to `echo "Agent <id> started"`.
+    pub command: Option<String>,
+    /// Arguments for the command.
+    pub command_args: Option<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -140,6 +144,71 @@ pub async fn spawn_agent(
 
     // Build clone URL: {base_url}/git/{project_id}/{repo_name}
     let clone_url = format!("{}/git/{}/{}", state.base_url, repo.project_id, repo.name);
+
+    // Launch a real process via LocalTarget and monitor its lifecycle.
+    {
+        let command = req.command.clone().unwrap_or_else(|| "echo".to_string());
+        let args = req
+            .command_args
+            .clone()
+            .unwrap_or_else(|| vec![format!("Agent {} started", agent.id)]);
+        let effective_work_dir = if std::path::Path::new(&worktree_path).exists() {
+            worktree_path.clone()
+        } else {
+            ".".to_string()
+        };
+        let spawn_config = gyre_ports::SpawnConfig {
+            name: agent.name.clone(),
+            command,
+            args,
+            env: std::collections::HashMap::new(),
+            work_dir: effective_work_dir,
+        };
+        let local = gyre_adapters::compute::LocalTarget;
+        match gyre_ports::ComputeTarget::spawn_process(&local, &spawn_config).await {
+            Ok(handle) => {
+                let agent_id_str = agent.id.to_string();
+                state
+                    .process_registry
+                    .lock()
+                    .await
+                    .insert(agent_id_str.clone(), handle.clone());
+
+                // Background monitor: watch for process exit and update agent status.
+                let state_mon = Arc::clone(&state);
+                tokio::spawn(async move {
+                    loop {
+                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                        let alive = gyre_ports::ComputeTarget::is_alive(
+                            &gyre_adapters::compute::LocalTarget,
+                            &handle,
+                        )
+                        .await
+                        .unwrap_or(false);
+                        if !alive {
+                            state_mon
+                                .process_registry
+                                .lock()
+                                .await
+                                .remove(&agent_id_str);
+                            if let Ok(Some(mut a)) =
+                                state_mon.agents.find_by_id(&Id::new(&agent_id_str)).await
+                            {
+                                if a.status == AgentStatus::Active {
+                                    let _ = a.transition_status(AgentStatus::Idle);
+                                    let _ = state_mon.agents.update(&a).await;
+                                }
+                            }
+                            break;
+                        }
+                    }
+                });
+            }
+            Err(e) => {
+                tracing::warn!(agent_id = %agent.id, "process spawn failed (best-effort): {e}");
+            }
+        }
+    }
 
     // Auto-track agent spawn
     let ev = AnalyticsEvent::new(


### PR DESCRIPTION
## Summary
- SpawnAgentRequest gains optional `command` + `command_args` fields
- Spawn handler launches real child process via LocalTarget
- Process registry tracks running agent PIDs on AppState
- Background monitor auto-transitions agent to Idle on exit
- Kill agent endpoint terminates actual process

## Test plan
- [x] 263 server tests pass
- [x] cargo clippy + fmt clean

Generated with [Claude Code](https://claude.com/claude-code)