### PR TITLE
docs: document M12.1 quality gates — README In Progress, 494 tests, 3 new endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,8 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/repos/{id}/branches` | List branches in repository |
 | `GET` | `/api/v1/repos/{id}/commits` | Commit log (`?branch=<name>&limit=50`) |
 | `GET` | `/api/v1/repos/{id}/diff` | Diff between refs (`?from=<ref>&to=<ref>`) |
+| `POST/GET` | `/api/v1/repos/{id}/gates` | Create / list quality gates for a repo (`GateType`: TestCommand, LintCommand, RequiredApprovals) (M12.1) |
+| `DELETE` | `/api/v1/repos/{id}/gates/{gate_id}` | Delete a quality gate (M12.1) |
 | `POST/GET` | `/api/v1/agents` | Register (returns auth_token) / list (`?status=`) |
 | `GET` | `/api/v1/agents/{id}` | Get agent |
 | `PUT` | `/api/v1/agents/{id}/status` | Update agent status |
@@ -126,7 +128,8 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `POST/GET` | `/api/v1/merge-requests/{id}/comments` | Add / list review comments |
 | `POST/GET` | `/api/v1/merge-requests/{id}/reviews` | Submit / list reviews (approve/request changes) |
 | `GET` | `/api/v1/merge-requests/{id}/diff` | Get MR diff |
-| `POST` | `/api/v1/merge-queue/enqueue` | Add approved MR to merge queue |
+| `GET` | `/api/v1/merge-requests/{id}/gates` | Get quality gate execution results for an MR (M12.1) |
+| `POST` | `/api/v1/merge-queue/enqueue` | Add approved MR to merge queue; triggers gate execution per repo gates (M12.1) |
 | `GET` | `/api/v1/merge-queue` | List merge queue entries (priority ordered) |
 | `DELETE` | `/api/v1/merge-queue/{id}` | Cancel queued entry |
 | `POST` | `/api/v1/repos/{id}/commits/record` | Record agent-commit mapping |

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M9: Functional UI | Done | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
 | M10: Persistent Storage | Done | SQLite persistence, real-time WebSocket events, git repo management |
 | M11: Agent Execution | In Progress | Real agent processes, TTY attach, agent logs, execution lifecycle |
-| M12: Quality Gates | Planned | Merge queue gates, repo mirroring, diff viewer |
+| M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
 
-490 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+494 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications.


### PR DESCRIPTION
## Summary

PR #62 (M12.1 quality gate framework) merged without documentation updates.

## Gaps fixed

**README:**
- M12: Quality Gates `Planned` → `In Progress`
- Test count: `490` → `494` (+4 new gate tests)

**AGENTS.md — 3 new endpoints:**

| Method | Path | Description |
|---|---|---|
| `POST/GET` | `/api/v1/repos/{id}/gates` | Create / list quality gates (`GateType`: TestCommand, LintCommand, RequiredApprovals) |
| `DELETE` | `/api/v1/repos/{id}/gates/{gate_id}` | Delete a quality gate |
| `GET` | `/api/v1/merge-requests/{id}/gates` | Get gate execution results for an MR |

**AGENTS.md — merge-queue/enqueue updated:**
- `POST /api/v1/merge-queue/enqueue` now triggers background gate execution for all gates configured on the repo (M12.1)

## Also noting

M11.2 TTY attach (spec deliverable: `GET /ws/agents/{id}/tty` + xterm.js) was skipped when CEO moved to M12. M11 stays `In Progress` in README until TTY attach lands.

🤖 DocGardener — doc gap from merged PR #62