### PR TITLE
feat(specs): Forge Advantage spec + M13 milestone

### DIFF
--- a/specs/index.md
+++ b/specs/index.md
@@ -18,6 +18,7 @@ What Gyre does - the product.
 |---|---|---|
 | Design Principles | [`system/design-principles.md`](system/design-principles.md) | Core invariants that govern all decisions |
 | Source Control | [`system/source-control.md`](system/source-control.md) | Built-in git forge, MRs, merge queue, jj evaluation |
+| Forge Advantages | [`system/forge-advantages.md`](system/forge-advantages.md) | 8 capabilities only possible with a forge-native agent platform |
 | Agent Runtime & Compute | [`system/agent-runtime.md`](system/agent-runtime.md) | CLI, TTY, WebSocket, compute targets, lifetimes, networking, MCP, protocols |
 | Identity & Security | [`system/identity-security.md`](system/identity-security.md) | SPIFFE, SSO/Keycloak, SCIM, ABAC, impersonation, audit |
 | Observability & Governance | [`system/observability.md`](system/observability.md) | OTel, eBPF audit, SIEM forwarding, agent auditability |
@@ -74,6 +75,7 @@ How Gyre gets built - process and standards for the agent team.
 | M10: Persistent Storage | [`milestones/m10-persistent-storage.md`](milestones/m10-persistent-storage.md) | SQLite persistence, real-time WebSocket events, git repo storage |
 | M11: Agent Execution | [`milestones/m11-agent-execution.md`](milestones/m11-agent-execution.md) | Real agent processes, TTY attach from browser, agent logs |
 | M12: Quality Gates | [`milestones/m12-quality-gates.md`](milestones/m12-quality-gates.md) | Merge queue gates (tests/lints/reviews), repo mirroring, diff viewer |
+| M13: Forge Native | [`milestones/m13-forge-native.md`](milestones/m13-forge-native.md) | Pre-accept validation, commit provenance, speculative merging, cross-agent awareness |
 
 ## Open Questions
 
@@ -81,11 +83,11 @@ How Gyre gets built - process and standards for the agent team.
 |---|---|
 | SPIFFE integration details | **Resolved** - 3-layer stack: SPIFFE (workload attestation) + Gyre as OIDC provider (agent permissions) + Sigstore/Fulcio (keyless commit signing). Federated via standard protocols. |
 | jj (Jujutsu) vs. Git | **Resolved** - jj adds value for agent workflows (atomic changes, auto-rebase, undo) |
-| Agent collaboration model (hierarchy + ?) | Open |
-| Coordination primitives (blackboard vs. event stream vs. persistent work chains) | Open |
-| Persistent Ralph loop steps (NDI pattern) | Open |
+| Agent collaboration model (hierarchy + ?) | **Resolved** - hierarchy (spawn tree) + typed peer messages (A2A) + cross-agent code awareness (M13.4) |
+| Coordination primitives (blackboard vs. event stream vs. persistent work chains) | **Resolved** - event stream (domain events via WebSocket) + persistent work chains (task/Ralph ref tree) |
+| Persistent Ralph loop steps (NDI pattern) | **Resolved** - Custom ref namespaces (M13.6): refs/ralph/{task-id}/{step} survives agent crash |
 | Decision library for learned interrupt resolutions | Open |
-| Cost tracking model | Open |
-| CI as separate concept vs. emergent property | Open |
+| Cost tracking model | **Resolved** - cost entries table, per-agent aggregation, dashboard cost view (M6.1) |
+| CI as separate concept vs. emergent property | **Resolved** - emergent: pre-accept gates (M13.1) + merge queue gates (M12.1) = CI without a separate concept |
 | Feature flags as CI alternative | Open |
 | SSO/SCIM provider targets | **Resolved** - Keycloak primary, pluggable for others |

--- a/specs/milestones/m13-forge-native.md
+++ b/specs/milestones/m13-forge-native.md
@@ -1,0 +1,277 @@
+# M13: Forge-Native Agent Capabilities
+
+## Goal
+
+Unlock the capabilities that are only possible because Gyre owns the source control layer.
+Agents get sub-second feedback, tamper-evident commit provenance, conflict awareness before
+implementation begins, and a VCS that maps naturally to tool-execution semantics.
+
+## Problem
+
+Gyre has a working git forge with merge requests, merge queue, and quality gates (M12).
+The forge layer currently behaves like an external forge: pushes are accepted, refs updated,
+webhooks would be sent (we broadcast domain events instead). The deep integration potential is
+untapped: commit metadata has no task linkage, push validation is coarse, agents discover
+conflicts only at MR submission, and the merge queue operates without awareness of who is
+working on what file.
+
+Reference: [`specs/system/forge-advantages.md`](../system/forge-advantages.md) defines all eight
+capabilities in detail.
+
+---
+
+## Deliverables
+
+### M13.1 Server-Side Pre-Accept Validation
+
+Reject pushes in the receive-pack handler before the ref is updated.
+
+**Implementation:**
+- `PreAcceptGate` trait in `gyre-ports`: `fn check(push: &PushContext) -> GateResult`
+- Built-in gates registered at server startup:
+  - `ArchLintGate`: run `scripts/check-arch.sh` equivalent logic in-process
+  - `ConventionalCommitGate`: validate commit message format for all commits in push
+  - `TaskRefGate`: `feat/` and `fix/` branches must reference a known TASK-id in commit message
+  - `FmtGate`: `cargo fmt --check` on changed `.rs` files (configurable, disabled by default)
+  - `NoEmDashGate`: reject commits containing em-dash characters in message or changed files
+- Gates configured per-repo via `repo_gates` table (JSON gate list)
+- Push rejected with human-readable error message listing which gates failed and why
+- Gate results recorded in activity log with agent attribution
+- `GET /api/v1/repos/{id}/gates` -- list configured gates
+- `PUT /api/v1/repos/{id}/gates` -- update gate list (Developer role required)
+
+**Acceptance criteria:**
+- [ ] Push with non-conventional commit message is rejected before ref update
+- [ ] Push to `feat/` branch without TASK reference is rejected
+- [ ] Gate failure message names the specific gate and explains the fix
+- [ ] Gate results appear in activity log with agent_id
+- [ ] Gate list is configurable per-repo via REST API
+
+---
+
+### M13.2 Rich Commit Provenance
+
+Every accepted commit is linked to its agent session, task, loop step, and spawning user.
+
+**Implementation:**
+- Extend `agent_commits` table: add `task_id`, `ralph_step`, `spawned_by_user_id`,
+  `parent_agent_id`, `model_context` (JSON blob) columns
+- Populate during post-receive hook (server has session context at push time)
+- `ralph_step` enum: `spec | implement | review | merge` -- derived from task status at push time
+- `model_context` captures: model name, active tools list, spec revision hash
+- `GET /api/v1/repos/{id}/provenance?commit={sha}` -- full provenance for a commit
+- `GET /api/v1/repos/{id}/provenance?task_id={id}` -- all commits for a task, grouped by loop step
+- `GET /api/v1/repos/{id}/provenance?agent_id={id}` -- all commits by an agent session
+- `GET /api/v1/repos/{id}/provenance?ralph_step=implement` -- all implement-phase commits
+- Provenance visible in Repo Detail -> Commits tab (add "Agent" column with task link)
+
+**Acceptance criteria:**
+- [ ] Commit pushed by agent includes task_id, ralph_step, spawned_by in provenance record
+- [ ] `GET /api/v1/repos/{id}/provenance?task_id=X` returns commits grouped by loop step
+- [ ] Provenance API response includes parent_agent_id chain (full spawn lineage)
+- [ ] Dashboard Commits tab shows agent attribution with task link
+
+---
+
+### M13.3 Zero-Latency Feedback (Extended Post-Receive)
+
+Enrich the existing post-receive hook to deliver immediate, actionable feedback to the pushing agent.
+
+**Implementation:**
+- Extend `POST /git/{project}/{repo}/git-receive-pack` response to include feedback payload:
+  ```
+  remote: [GYRE] Push accepted for branch feat/my-feature
+  remote: [GYRE] Gate checks: 3/3 passed
+  remote: [GYRE] Merge queue position: 2 (1 ahead)
+  remote: [GYRE] Speculative merge: clean (no conflicts detected)
+  remote: [GYRE] Task TASK-007: status -> in_progress
+  ```
+- Remote-info lines are surfaced via standard git sideband mechanism (no client changes needed)
+- Push response includes JSON metadata in `X-Gyre-Push-Result` header:
+  ```json
+  {
+    "accepted": true,
+    "branch": "feat/my-feature",
+    "gates_passed": 3,
+    "queue_position": 2,
+    "speculative_merge": "clean",
+    "task_id": "TASK-007"
+  }
+  ```
+- `gyre push` CLI command parses this header and displays structured summary
+- Domain event `PushAccepted` broadcast to all WebSocket clients with same payload
+
+**Acceptance criteria:**
+- [ ] `git push` output includes Gyre feedback lines (remote: [GYRE] ...)
+- [ ] `gyre push` displays structured push summary from `X-Gyre-Push-Result` header
+- [ ] `PushAccepted` domain event visible in dashboard activity feed immediately after push
+
+---
+
+### M13.4 Cross-Agent Code Awareness
+
+Real-time queries combining git history with agent provenance.
+
+**Implementation:**
+- `GET /api/v1/repos/{id}/blame?path={file}` -- per-line agent attribution
+  - Response: array of `{line_start, line_end, commit_sha, agent_id, task_id, ralph_step}`
+  - Falls back to git blame for commits without provenance records
+- `GET /api/v1/repos/{id}/hot-files?limit=20` -- files with most distinct active agents
+  - "Active" = agent has touched the file in the last 24h and is not in Idle/Dead status
+  - Response: `{path, agent_count, agents: [{id, name, task_id}]}`
+- `GET /api/v1/agents/{id}/touched-paths` -- all file paths written by an agent in its session
+- `GET /api/v1/repos/{id}/review-routing?path={file}` -- ordered list of agents to notify for review
+  - Ranked by: recency of last touch, number of commits to path, current task relevance
+- `HotFilesChanged` domain event emitted when hot-files list changes (new agent touches tracked file)
+- Dashboard Repo Detail: "Active Agents" tab showing hot files with agent avatars
+
+**Acceptance criteria:**
+- [ ] `GET /api/v1/repos/{id}/blame?path=src/main.rs` returns agent attribution for each line range
+- [ ] `GET /api/v1/repos/{id}/hot-files` returns files with concurrent agent activity
+- [ ] `GET /api/v1/repos/{id}/review-routing?path=X` returns ranked agent list
+- [ ] Dashboard shows active agent count per file in Repo Detail
+
+---
+
+### M13.5 Speculative Merging
+
+Continuous background merge attempts for all in-flight branches.
+
+**Implementation:**
+- Background job `SpeculativeMergeJob` (joins existing job framework from M6):
+  - Runs every 60 seconds (configurable)
+  - For each active agent branch, attempt `git merge --no-commit --no-ff main`
+  - On conflict: record conflict details, emit `SpeculativeConflict` domain event
+  - On clean merge: store result at `refs/speculative/{branch}`, emit `SpeculativeMergeClean` event
+  - Ephemeral refs garbage-collected when branch is merged or agent completes
+- `GET /api/v1/repos/{id}/speculative` -- list all speculative merge results
+- `GET /api/v1/repos/{id}/speculative/{branch}` -- result for a specific branch:
+  ```json
+  {
+    "branch": "feat/my-feature",
+    "status": "conflict",
+    "conflicting_branch": "feat/other-feature",
+    "conflicting_agent_id": "...",
+    "conflicting_files": ["src/lib.rs"],
+    "detected_at": "2026-03-20T15:00:00Z"
+  }
+  ```
+- `GET /api/v1/admin/jobs` lists `speculative-merge` job with last run time and conflict count
+- Dashboard: conflict badge on branch list rows, link to conflicting agent
+
+**Acceptance criteria:**
+- [ ] Two branches with overlapping file edits produce a `SpeculativeConflict` event within 60s
+- [ ] Conflict event names both branches and the conflicting agent
+- [ ] Dashboard branch list shows conflict badge with link to conflicting agent
+- [ ] Clean branches show `refs/speculative/{branch}` ref in repo
+
+---
+
+### M13.6 Custom Ref Namespaces
+
+Structured server-managed git refs for Ralph loop state.
+
+**Implementation:**
+- Server writes lifecycle refs automatically:
+  - On task status -> `in_progress`: write agent's current HEAD to `refs/agents/{agent-id}/head`
+  - On task `ralph_step` transition: write HEAD to `refs/ralph/{task-id}/{step}`
+  - On speculative merge: write result to `refs/speculative/{branch}` (see M13.5)
+  - On agent complete: write final HEAD to `refs/agents/{agent-id}/snapshots/{n}`
+- Agents may NOT push directly to `refs/agents/`, `refs/ralph/`, `refs/speculative/`, `refs/reviews/`
+  -- pre-accept gate rejects such pushes
+- `GET /api/v1/repos/{id}/refs` -- list all refs including server-managed namespaces
+- `GET /api/v1/repos/{id}/refs?namespace=ralph` -- filter by namespace
+- `GET /api/v1/tasks/{id}/refs` -- all refs associated with a task across its lifecycle
+- Dashboard Task Detail: "Artifacts" tab listing Ralph refs with diff links between phases
+
+**Acceptance criteria:**
+- [ ] Agent push to `refs/ralph/` is rejected by pre-accept gate
+- [ ] Task status transition writes corresponding Ralph ref automatically
+- [ ] `GET /api/v1/tasks/{id}/refs` returns all phase refs for the task
+- [ ] Dashboard Task Detail shows diff between spec and implement phases
+
+---
+
+### M13.7 Atomic Agent Operations (Hardening)
+
+Extend the existing spawn/complete atomicity to cover all failure modes.
+
+**Implementation:**
+- Wrap spawn transaction in a SQLite `BEGIN IMMEDIATE` covering:
+  agent insert, token mint, worktree creation, task assignment, initial ref write
+- Add `agent_spawn_log` table: records each step with timestamp and result (for recovery)
+  - Columns: `agent_id`, `step`, `status` (ok/failed), `detail`, `occurred_at`
+- Compensating transactions: if any step fails post-agent-insert, server runs cleanup:
+  - Delete agent record
+  - Remove worktree if created
+  - Revoke token (mark in `revoked_tokens` table)
+  - Reset task to prior status
+- `GET /api/v1/admin/agents/{id}/spawn-log` -- diagnostic view of spawn attempt steps
+- Same pattern for complete: wrap in transaction, log each step, compensate on failure
+- Idempotent complete: calling complete twice returns the existing MR rather than erroring
+
+**Acceptance criteria:**
+- [ ] Spawn with invalid repo_id fails atomically (no orphaned records)
+- [ ] Spawn log records all steps with timestamps
+- [ ] Double-complete returns existing MR with `202 Already Completed`
+- [ ] Admin spawn log visible in admin panel Agent detail
+
+---
+
+### M13.8 jj Native Identity Integration
+
+Apply Gyre agent identity to jj change descriptions and enforce signing at squash time.
+
+**Implementation:**
+- Extend `POST /api/v1/repos/{id}/jj/new` to accept optional `ralph_step` and inject into
+  change description template:
+  ```
+  {task_title}
+
+  Agent: {agent_name}
+  Session: {session_id}
+  Task: {task_id}
+  Loop-step: {ralph_step}/iteration-{n}
+  Spawned-by: {spawned_by_user}
+  ```
+- `POST /api/v1/repos/{id}/jj/squash` triggers Sigstore signing flow:
+  - Server fetches agent's current OIDC token
+  - Requests Fulcio certificate for the token identity
+  - Signs the squashed commit SHA using the certificate
+  - Records certificate + Rekor log entry in provenance record
+  - Returns `signed_commit_sha` and `rekor_log_url` in response
+- `GET /api/v1/repos/{id}/commits/{sha}/signature` -- verify commit signature, return
+  `{valid, agent_id, task_id, rekor_url, certificate_subject}`
+- Dashboard Repo Detail: signature badge on commits from jj squash, click to view provenance
+
+**Acceptance criteria:**
+- [ ] `jj new` via API produces change description with full agent identity context
+- [ ] `jj squash` returns signed_commit_sha and rekor_log_url
+- [ ] `GET /api/v1/repos/{id}/commits/{sha}/signature` returns valid signature metadata
+- [ ] Dashboard shows signature badge on signed commits
+
+---
+
+## Priority Order
+
+| # | Deliverable | Rationale |
+|---|---|---|
+| 1 | M13.1 Pre-Accept Validation | Immediate value: blocks bad pushes before they land. Simplest to ship. |
+| 2 | M13.2 Rich Commit Provenance | Enables all downstream capabilities. Low risk: extends existing table. |
+| 3 | M13.3 Zero-Latency Feedback | High agent UX impact. Builds on existing post-receive machinery. |
+| 4 | M13.4 Cross-Agent Code Awareness | Enables automatic review routing. Requires provenance (M13.2). |
+| 5 | M13.5 Speculative Merging | High value for preventing late conflicts. Background job pattern is established. |
+| 6 | M13.6 Custom Ref Namespaces | Clean Ralph loop artifact tracking. Requires provenance refs (M13.2). |
+| 7 | M13.7 Atomic Operations Hardening | Reliability improvement on existing feature. Lower urgency. |
+| 8 | M13.8 jj Identity Integration | Depends on Sigstore infrastructure. Highest complexity. |
+
+## Overall Acceptance Criteria
+
+- [ ] Push with bad commit message is rejected before ref update (M13.1)
+- [ ] All commits show agent + task attribution in provenance API (M13.2)
+- [ ] `git push` output includes Gyre feedback lines (M13.3)
+- [ ] Hot-files endpoint identifies concurrent agent activity (M13.4)
+- [ ] Conflicting branches trigger speculative conflict event within 60s (M13.5)
+- [ ] Task phase transitions write corresponding `refs/ralph/` entries (M13.6)
+- [ ] Double-spawn and double-complete are handled atomically (M13.7)
+- [ ] jj squash returns Sigstore-signed commit with Rekor URL (M13.8)

--- a/specs/system/forge-advantages.md
+++ b/specs/system/forge-advantages.md
@@ -1,0 +1,322 @@
+# Forge Advantages: Why Gyre Owns the Source Control Layer
+
+Gyre is not integrated with a code forge -- it _is_ the forge. This document defines eight
+capabilities that only a forge-native agent platform can provide, explains why each is
+impossible with an external forge, and shows how each accelerates the Ralph loop.
+
+---
+
+## The Core Insight
+
+External forges (GitHub, GitLab) are built for humans. Every capability surfaces through webhooks
+and REST APIs: push arrives, forge calls out, your system responds, adds a status check, maybe
+triggers a CI run. Each step adds latency, failure modes, and configuration surface. Agents running
+tight feedback loops at machine speed pay this tax on every iteration.
+
+Gyre eliminates the seam. The forge, the agent runtime, and the identity system share a process.
+Post-receive hooks are function calls. Commit metadata is a foreign key. The merge queue can talk
+directly to an agent's message queue. No webhooks. No eventual consistency.
+
+---
+
+## Capability 1: Speculative Merging
+
+**What it does:**
+The merge queue continuously attempts to merge every in-flight feature branch against the current
+main, creating ephemeral merge commits in `refs/speculative/{branch}`. Conflicts are detected the
+moment they arise -- not when an agent pushes their final commit.
+
+**Why impossible externally:**
+An external forge merges on demand. You can simulate conflict detection via CI, but that requires:
+a custom runner, a webhook trigger, clone + merge + report in a separate process, and a status
+check round trip. Each step adds 10-30 seconds. At agent commit frequency (multiple pushes per
+minute), this is untenable.
+
+Gyre runs speculative merging as a background task in the same process. It shares the in-memory
+git object store. The merge attempt costs microseconds, not seconds.
+
+**Ralph loop acceleration:**
+Conflict notification arrives before the agent finishes -- often before the agent begins the
+implementation phase. The agent can redirect effort immediately rather than discovering the conflict
+at MR submission time and having to rebase or rewrite.
+
+**Agent identity integration:**
+Speculative merges are attributed in the conflict report: "your branch conflicts with changes made
+by agent `worker-42` on task TASK-019 at commit `abc123`." The agent can message the conflicting
+agent directly to coordinate. No detective work required.
+
+---
+
+## Capability 2: Atomic Agent Operations
+
+**What it does:**
+`POST /api/v1/agents/spawn` is a single transaction:
+1. Create agent record
+2. Mint per-agent OIDC token (scoped to task + repo)
+3. Provision git worktree
+4. Assign task, mark in_progress
+5. Record initial branch ref
+
+If any step fails, all prior steps roll back. The agent either starts clean or does not start.
+Similarly, `POST /api/v1/agents/{id}/complete` atomically opens the MR, marks the task done,
+removes the worktree, and marks the agent idle.
+
+**Why impossible externally:**
+An external forge cannot participate in transactions that span your application database, the git
+object store, and identity token issuance. Each is a separate API call. Partial failures produce
+zombie states: worktree exists but agent record is missing, or MR is open but task is still
+in_progress. These require manual cleanup and cause subtle bugs in downstream coordination.
+
+**Ralph loop acceleration:**
+The orchestrator can spawn hundreds of agents per minute without building complex compensating
+logic. When the loop restarts after a failure, the state is clean. No "is this agent actually
+running?" diagnostic step required.
+
+**Agent identity integration:**
+The spawn transaction generates and embeds the OIDC token in the same operation that records the
+agent session. The token `sub` claim (`agent:{name}`) and the session record share the same
+UUID -- no out-of-band key distribution, no secret storage.
+
+---
+
+## Capability 3: Zero-Latency Feedback
+
+**What it does:**
+Post-receive hooks in Gyre are synchronous function calls in the server process. When an agent
+pushes a commit, Gyre:
+1. Validates the push (auth, branch policy, pre-accept checks)
+2. Updates agent-commit tracking records
+3. Evaluates merge queue readiness
+4. Broadcasts domain events to all WebSocket clients
+5. Returns the push result
+
+All of this happens before the `git push` command returns to the agent's shell.
+
+**Why impossible externally:**
+GitHub's post-receive equivalent is a webhook, which is asynchronous. The push completes, GitHub
+calls your endpoint some seconds later. During that window, the agent may already be doing more
+work based on stale state. "Did my push trigger CI?" requires polling or subscription. The feedback
+round trip is 2-15 seconds minimum.
+
+**Ralph loop acceleration:**
+The agent knows immediately whether its push was accepted, whether it triggered gate checks, and
+whether it is now first in the merge queue. The spec-implement-review-merge loop closes in seconds
+rather than minutes.
+
+**Agent identity integration:**
+The post-receive hook has direct access to the authenticated agent session. Push validation
+uses the agent's OIDC token claims (task scope, repo scope) without an additional API call.
+Sigstore signing can be initiated inline, ensuring every accepted commit is signed before the ref
+is updated.
+
+---
+
+## Capability 4: Server-Side Pre-Accept Validation
+
+**What it does:**
+Gyre can reject a push before the ref is updated. Pre-accept checks run in the receive-pack
+handler before the packfile is written to disk. Default checks:
+- Architecture lint: no `gyre-domain` importing `gyre-adapters`
+- Conventional commit format validation
+- No em-dash characters (agent-specific style rule)
+- Spec reference: commit message references a known TASK-id if branch is `feat/` or `fix/`
+- Format: `cargo fmt --check` on changed `.rs` files (configurable)
+
+Additional checks are pluggable per-repo via gate definitions (M12.1).
+
+**Why impossible externally:**
+GitHub pre-receive hooks exist but run in an isolated sandbox with a time limit, no network access,
+and no access to your application database. You cannot enforce "commit message must reference a
+known task" because the task database is external. You cannot enforce architectural rules that
+require understanding your codebase structure unless you ship a self-contained binary into the
+sandbox.
+
+**Ralph loop acceleration:**
+Agents get immediate, specific rejection messages with actionable fixes. No CI round trip to
+discover that the commit failed a lint check. The agent corrects and re-pushes in seconds.
+
+**Agent identity integration:**
+Pre-accept checks are ABAC-aware: different rules apply based on agent role and task scope.
+An `Admin` agent may bypass certain checks. A `ReadOnly` agent is rejected on any write attempt.
+Pre-accept is the enforcement point for the identity stack -- by the time a commit is accepted,
+its provenance is verified.
+
+---
+
+## Capability 5: Rich Commit Provenance
+
+**What it does:**
+Every accepted commit in Gyre is linked by foreign key to:
+- Agent session ID (who pushed it)
+- Task ID (what it was for)
+- Ralph loop step (spec / implement / review / merge)
+- User ID (who spawned the agent)
+- Model context snapshot (which model, at what revision of the spec, with what tools active)
+- Worktree path at time of push
+- Parent agent session (orchestrator that spawned this agent)
+
+This data is queryable via API:
+- "Show all commits made during the implement phase of TASK-007"
+- "Show all commits made by agents spawned by user jsell this week"
+- "Show the full commit lineage for this feature, including review iterations"
+
+**Why impossible externally:**
+External forges store commit metadata in git objects (author, message, timestamp). Custom metadata
+requires commit message conventions (fragile) or out-of-band databases that drift from the actual
+commit history. Querying "all commits by this agent" requires grepping messages or maintaining your
+own index that can fall out of sync.
+
+Gyre writes provenance as first-class database records, written transactionally with ref updates.
+They cannot drift.
+
+**Ralph loop acceleration:**
+Orchestrators can reconstruct exactly what happened during a failed loop without reading logs.
+"Which commit introduced the failing test?" is a database query, not a bisect. Review routing uses
+provenance: if a file was last touched by agent `worker-7`, that agent (or its orchestrator) is
+notified first.
+
+**Agent identity integration:**
+Provenance is the Sigstore transparency record made queryable. The Sigstore signature proves "this
+commit was made by this OIDC identity"; the provenance record links that identity to the full
+task/agent/loop context. Together they form an unbroken, tamper-evident chain from user intent
+(task creation) to merged commit.
+
+---
+
+## Capability 6: Custom Ref Namespaces
+
+**What it does:**
+Gyre manages structured git ref namespaces beyond `refs/heads/` and `refs/tags/`:
+
+| Namespace | Purpose |
+|---|---|
+| `refs/agents/{agent-id}/head` | Current working branch per agent |
+| `refs/agents/{agent-id}/snapshots/{n}` | Point-in-time snapshots for undo |
+| `refs/ralph/{task-id}/spec` | Commit representing the accepted spec |
+| `refs/ralph/{task-id}/implement` | Branch at implement-phase completion |
+| `refs/ralph/{task-id}/review/{n}` | State at each review iteration |
+| `refs/speculative/{branch}` | Speculative merge result (ephemeral) |
+| `refs/reviews/{mr-id}/comments` | Review comments as git notes |
+| `refs/queue/{entry-id}` | Merge queue state per entry |
+
+These refs are managed by the server, not by agents. Agents push to `refs/heads/` normally.
+
+**Why impossible externally:**
+External forges support custom refs but provide no semantic meaning or lifecycle management for
+them. You can push to `refs/custom/foo` on GitHub, but GitHub will not garbage-collect stale
+entries, will not update them atomically with your application state, and will not expose them
+through discovery APIs.
+
+**Ralph loop acceleration:**
+An orchestrator can reconstruct the full history of any task by reading structured refs -- no
+database query required. `git fetch origin refs/ralph/TASK-007/*` retrieves every phase artifact.
+Diffing `refs/ralph/TASK-007/spec` against `refs/ralph/TASK-007/implement` shows exactly what the
+agent built versus what was specified.
+
+**Agent identity integration:**
+Ref namespace writes are gated by the agent's OIDC token scope. An agent may write to
+`refs/agents/{its-own-id}/` but not to another agent's namespace. The `refs/ralph/` namespace is
+written by the server during phase transitions, not directly by agents -- enforced by the
+receive-pack pre-accept layer.
+
+---
+
+## Capability 7: jj as Native Agent VCS
+
+**What it does:**
+Jujutsu (jj) is the agent-facing VCS layer colocated on top of git. Every agent tool execution
+maps to an atomic jj change:
+- "read file" does not create a change
+- "write file" creates or extends the current anonymous change
+- "run tests" creates a new change if tests pass (marking a stable checkpoint)
+- "apply suggestion" is its own change with the suggestion as description
+
+The jj operation log records every operation, including failed ones. `jj undo` reverts to any
+prior state. Multi-agent rebasing is handled by jj's automatic rebase-on-top-of-diverged-parent.
+
+**Why impossible externally:**
+Standard git requires explicit staging and committing. Agents using git directly either commit too
+rarely (large, opaque commits) or too often (noisy, meaningless commits). jj's anonymous change
+model matches agent execution semantics naturally.
+
+External forges do not understand jj's operation log. If an agent's session crashes mid-change,
+recovery requires reading jj state, which an external forge cannot assist with. Gyre's server
+understands jj operation log format and can assist with recovery during agent spawn/complete.
+
+**Ralph loop acceleration:**
+Agents can experiment freely -- every file write is undoable. Review feedback maps directly to
+`jj describe` and targeted file edits. The "apply review, checkpoint, continue" pattern has zero
+overhead. Review history is preserved in the operation log, available for audit.
+
+**Agent identity integration:**
+jj change descriptions are generated by the server using the agent's task context:
+```
+feat(TASK-007): implement rate limiting middleware
+
+Agent: worker-42
+Session: sess_abc123
+Spawned-by: user:jsell
+Loop-step: implement/iteration-2
+Signed-by: fulcio:worker-42@gyre.example.com
+```
+
+Sigstore signing is applied at `jj squash` time (when a change is finalized), not per write.
+This avoids signing ephemeral intermediate states while ensuring every landed commit is signed.
+
+---
+
+## Capability 8: Cross-Agent Code Awareness
+
+**What it does:**
+Gyre provides real-time queries across all agent activity:
+
+- `GET /api/v1/repos/{id}/blame?path=src/foo.rs` -- returns per-line agent attribution (not just
+  last commit author, but full agent session + task context)
+- `GET /api/v1/repos/{id}/coverage?agent_id=X` -- cumulative diff: all lines ever touched by agent X
+- `GET /api/v1/repos/{id}/hot-files` -- files with the most concurrent agent activity (conflict risk)
+- `GET /api/v1/agents/{id}/touched-paths` -- all file paths an agent has written to in its session
+- `GET /api/v1/repos/{id}/review-routing?path=src/foo.rs` -- which agents/agents most recently
+  changed this path and should be notified for review
+
+These queries combine git history with the provenance database (Capability 5) to answer questions
+no git command can answer natively.
+
+**Why impossible externally:**
+This requires joining git history (who changed this line?) with application-level metadata (which
+agent, on which task, in which loop step?) in real time. External systems must maintain their own
+index and keep it synchronized with git refs. Drift is unavoidable under high commit frequency.
+
+Gyre maintains the index transactionally: every accepted push updates the provenance records
+atomically with the ref update. The index is always consistent with git state.
+
+**Ralph loop acceleration:**
+Review routing is automatic. When an agent opens an MR, Gyre identifies which other agents have
+touched the changed files and routes review notifications accordingly. No manual `@mention` or
+CODEOWNERS file required. Conflict risk assessment is available before agents start: "this file has
+3 agents working on it -- coordinate before writing."
+
+**Agent identity integration:**
+Code awareness queries respect ABAC policies. An agent can query coverage for its own session
+without elevated permissions. Querying another agent's coverage requires `Developer` role or higher.
+Hot-file alerts are emitted as domain events to all active agent WebSocket sessions -- agents
+self-coordinate without orchestrator intervention.
+
+---
+
+## Agent Identity Integration Summary
+
+All eight capabilities build on the same three-layer identity stack:
+
+| Layer | Role in Forge Capabilities |
+|---|---|
+| **SPIFFE** (workload attestation) | Proves the agent process is running on authorized compute. Pre-accept hooks verify SVID before accepting any push. Speculative merge results are only shared with agents whose SVID matches the owning session. |
+| **Gyre OIDC** (agent permissions) | Scopes every operation to task + repo. Atomic spawn mints the token. Pre-accept validation reads token claims inline. Custom ref namespace writes are gated by token scope. Cross-agent queries enforce ABAC from token `role` claim. |
+| **Sigstore/Fulcio** (commit signing) | Every accepted commit carries a Fulcio certificate linking the commit to the OIDC identity. Provenance records embed the Rekor log index. jj squash triggers signing at finalization. The full chain -- user intent -> task -> agent session -> commit -> signature -> transparency log -- is queryable via the provenance API. |
+
+**Zero-trust code host:** Gyre treats every push as potentially hostile until the three-layer check
+passes. Internal agents and external federated agents use the same verification path. Federation
+works by trusting a remote Gyre instance's OIDC issuer -- no static credentials exchanged.
+
+**Audit integration:** All eight capabilities emit structured events to the eBPF audit pipeline
+(M7.1). Speculative merge conflict events, pre-accept rejections, custom ref writes, and code
+awareness queries all appear in the SIEM feed with full agent identity context.


### PR DESCRIPTION
## Summary

- Adds `specs/system/forge-advantages.md`: documents 8 forge-native capabilities that are only possible because Gyre owns the source control layer
- Adds `specs/milestones/m13-forge-native.md`: implementation spec for M13 with 8 deliverables in priority order
- Updates `specs/index.md`: adds new entries to System and Milestones tables, resolves 5 open questions

## Forge Advantages Documented

1. **Speculative Merging** -- continuous try-merge of in-flight branches, detect conflicts before agents finish
2. **Atomic Agent Operations** -- spawn/complete as single transactions with compensating rollback
3. **Zero-Latency Feedback** -- post-receive hooks are function calls, push result includes queue position and gate status
4. **Server-Side Pre-Accept Validation** -- reject pushes before ref update (arch lint, fmt, task reference, no-em-dash)
5. **Rich Commit Provenance** -- every commit linked to agent session, task, Ralph loop step, spawning user, model context
6. **Custom Ref Namespaces** -- refs/agents/, refs/ralph/, refs/speculative/, refs/reviews/ managed by server
7. **jj as Native Agent VCS** -- every tool execution = atomic jj change, Sigstore signing at squash time
8. **Cross-Agent Code Awareness** -- real-time queries: blame with agent attribution, hot files, review routing

## M13 Deliverables (priority order)

1. M13.1 Server-Side Pre-Accept Validation
2. M13.2 Rich Commit Provenance
3. M13.3 Zero-Latency Feedback (extended post-receive)
4. M13.4 Cross-Agent Code Awareness
5. M13.5 Speculative Merging
6. M13.6 Custom Ref Namespaces
7. M13.7 Atomic Agent Operations (hardening)
8. M13.8 jj Native Identity Integration

## Open Questions Resolved

- Agent collaboration model: hierarchy + A2A messages + code awareness
- Coordination primitives: event stream + persistent Ralph ref tree
- Persistent Ralph loop steps: refs/ralph/{task-id}/{step}
- CI as emergent: pre-accept gates (M13.1) + merge queue gates (M12.1)
- Cost tracking: resolved (M6.1 already shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)