### PR TITLE
docs: add M13 Forge Native to README and AGENTS.md (PR #67)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -608,6 +608,8 @@ Key specs to read before making changes:
 | M10 milestone deliverables | [specs/milestones/m10-persistent-storage.md](specs/milestones/m10-persistent-storage.md) |
 | M11 milestone deliverables | [specs/milestones/m11-agent-execution.md](specs/milestones/m11-agent-execution.md) |
 | M12 milestone deliverables | [specs/milestones/m12-quality-gates.md](specs/milestones/m12-quality-gates.md) |
+| M13 milestone deliverables | [specs/milestones/m13-forge-native.md](specs/milestones/m13-forge-native.md) |
+| Forge-native advantages | [specs/system/forge-advantages.md](specs/system/forge-advantages.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ All specifications live in [`specs/`](specs/index.md). Start there.
 | M10: Persistent Storage | Done | SQLite persistence, real-time WebSocket events, git repo management |
 | M11: Agent Execution | In Progress | Real agent processes, TTY attach, agent logs, execution lifecycle |
 | M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
+| M13: Forge Native | Planned | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
 
 494 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

Documentation gaps from merged PR #67 (feat(specs): Forge Advantage spec + M13 milestone):

- **README.md**: milestone table was missing M13 row
- **AGENTS.md**: Architecture Decisions table was missing M13 spec link and forge-advantages link

## Changes

- `README.md`: add `| M13: Forge Native | Planned | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |`
- `AGENTS.md`: add M13 milestone deliverables link + Forge-native advantages link to Architecture Decisions table

🤖 DocGardener — automated documentation gap detection