### PR TITLE
docs: M11.2 TTY endpoint, M11 Done, 497 tests (PR #70)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `POST` | `/api/v1/agents/{id}/logs` | Append a log line to the agent's log buffer (M11.2) |
 | `GET` | `/api/v1/agents/{id}/logs` | Paginated agent log lines (`?limit=100&offset=0`) (M11.2) |
 | `GET` | `/api/v1/agents/{id}/logs/stream` | SSE live feed of new log lines for an agent (M11.2) |
+| `GET` | `/ws/agents/{id}/tty` | WebSocket TTY attach — auth via first-message Bearer token; replays buffered logs then streams live PTY output (M11.2) |
 | `POST/GET` | `/api/v1/tasks` | Create / list (`?status=&assigned_to=&parent_task_id=`) |
 | `GET/PUT` | `/api/v1/tasks/{id}` | Read / update task |
 | `PUT` | `/api/v1/tasks/{id}/status` | Transition task status |
@@ -451,7 +452,7 @@ Access at `http://localhost:3000` after starting the server. Admin Panel require
 - **Sidebar** (M8.1): grouped nav sections (Overview / Source Control / Agents / Operations / Admin), collapsible to icon-only mode via chevron toggle, server status footer.
 - **Global Search** (M8.1): Cmd+K opens `SearchBar` overlay with keyboard navigation across agents, tasks, repos, and MRs.
 - **Activity Feed** (M8.2): timeline layout with colored event-type nodes, multi-select filter pills (toggle per event type), relative timestamps, skeleton loading, `EmptyState` when no events match.
-- **Agent List** (M8.2 + M11.2): 3-column card grid with table-view toggle, status filter pills, skeleton grid on load, slide-in detail panel with tabbed Info/Logs view. Logs tab shows scrollable monospace agent output with live SSE streaming (M11.2).
+- **Agent List** (M8.2 + M11.2): 3-column card grid with table-view toggle, status filter pills, skeleton grid on load, slide-in detail panel with tabbed Info/Logs/Terminal view. Logs tab shows scrollable monospace agent output with live SSE streaming; Terminal tab streams live PTY output via `/ws/agents/{id}/tty` (M11.2).
 - **Task Board** (M8.2 + M9.2): kanban columns with semantic color-coded top borders per status, `Badge` component for priority, `EmptyState` per empty column, skeleton loading. "New Task" button opens Modal (title, description, priority, status) -> POST `/api/v1/tasks`; card appears in the correct column immediately.
 - **Project List** (M8.2 + M9.2): responsive card grid, skeleton loading, `EmptyState` when no projects exist. "New Project" button opens Modal (name + description) -> POST `/api/v1/projects`. Selecting a project shows "Add Repo" button -> Modal -> POST `/api/v1/repos`. Toast notifications on success/error.
 - **Repo Detail** (M8.2): uses `lib/Tabs` + `lib/Table` components, `Badge` for MR status, relative timestamps, `EmptyState` per empty tab.

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M8: Frontend Excellence | Done | Red Hat brand design system, polished dashboard UX, component library, consistent user journeys, dark theme |
 | M9: Functional UI | Done | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
 | M10: Persistent Storage | Done | SQLite persistence, real-time WebSocket events, git repo management |
-| M11: Agent Execution | In Progress | Real agent processes, TTY attach, agent logs, execution lifecycle |
+| M11: Agent Execution | Done | Real agent processes, TTY attach, agent logs, execution lifecycle |
 | M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
 | M13: Forge Native | Planned | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
 
-494 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+497 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications and [`AGENTS.md`](AGENTS.md) for the complete API and developer reference.


### PR DESCRIPTION
## Summary

Documentation gaps from merged PR #70 (feat(server): M11.2 TTY attach):

- **AGENTS.md**: `GET /ws/agents/{id}/tty` WebSocket TTY endpoint was not documented
- **AGENTS.md**: Agent List dashboard description still said "Info/Logs" tabs — now 3 tabs: Info, Logs, Terminal
- **README**: M11 Agent Execution still showed "In Progress" — all M11 deliverables are now shipped (M11.1 spawn processes, M11.2 logs, M11.2 TTY attach)
- **README**: test count 494 -> 497 (PR #70 added 3 new unit tests)

## Changes

- `AGENTS.md`: new row for `GET /ws/agents/{id}/tty` after logs endpoints
- `AGENTS.md`: Agent List dashboard entry updated with Terminal tab reference
- `README.md`: M11 status In Progress -> Done
- `README.md`: 494 -> 497 tests passing

🤖 DocGardener — automated documentation gap detection