### PR TITLE
docs: document M12.2 mirror API endpoints, update test count to 498 (PR #71)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET/PUT/DELETE` | `/api/v1/projects/{id}` | Read / update / delete project |
 | `POST/GET` | `/api/v1/repos` | Create / list repos (`?project_id=`); response includes mirror fields (`is_mirror`, `mirror_url`, `mirror_interval_secs`, `last_mirror_sync`) (M12.2) |
 | `GET` | `/api/v1/repos/{id}` | Get repository (includes mirror fields) |
+| `POST` | `/api/v1/repos/mirror` | Create a pull mirror from an external git URL (bare clone + periodic background sync) (M12.2) |
+| `POST` | `/api/v1/repos/{id}/mirror/sync` | Manually trigger a fetch sync on a mirror repo (M12.2) |
 | `GET` | `/api/v1/repos/{id}/branches` | List branches in repository |
 | `GET` | `/api/v1/repos/{id}/commits` | Commit log (`?branch=<name>&limit=50`) |
 | `GET` | `/api/v1/repos/{id}/diff` | Diff between refs (`?from=<ref>&to=<ref>`) |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
 | M13: Forge Native | Planned | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
 
-497 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+498 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications and [`AGENTS.md`](AGENTS.md) for the complete API and developer reference.


### PR DESCRIPTION
## Summary

Replaces closed PR #74 with clean base on updated main.

Documentation gaps from merged PR #71 (feat: M12.2+M12.3 remediation):

- **AGENTS.md**: `POST /api/v1/repos/mirror` — create pull mirror from external git URL
- **AGENTS.md**: `POST /api/v1/repos/{id}/mirror/sync` — manually trigger fetch sync on mirror
- **README**: test count 497 -> 498 (CI-verified: 129+23+1+8+65+271+1 = 498 passing after PRs #70+#71)

🤖 DocGardener — automated documentation gap detection