### PR TITLE
docs: document M13.4 code awareness + M13.5 speculative merge (541 tests)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,12 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/repos/{id}/diff` | Diff between refs (`?from=<ref>&to=<ref>`) |
 | `POST/GET` | `/api/v1/repos/{id}/gates` | Create / list quality gates for a repo (`GateType`: TestCommand, LintCommand, RequiredApprovals) (M12.1) |
 | `DELETE` | `/api/v1/repos/{id}/gates/{gate_id}` | Delete a quality gate (M12.1) |
+| `GET/PUT` | `/api/v1/repos/{id}/push-gates` | Get / set active pre-accept push gates for a repo (built-in: ConventionalCommit, TaskRef, NoEmDash) (M13.1) |
+| `GET` | `/api/v1/repos/{id}/blame?path={file}` | Per-line agent attribution — which agent last touched each line (M13.4) |
+| `GET` | `/api/v1/repos/{id}/hot-files?limit=20` | Files with the most concurrent active agents in the last 24h (M13.4) |
+| `GET` | `/api/v1/repos/{id}/review-routing?path={file}` | Ordered list of agents to request review from, ranked by recency and commit count (M13.4) |
+| `GET` | `/api/v1/repos/{id}/speculative` | List all speculative merge results for active branches (M13.5) |
+| `GET` | `/api/v1/repos/{id}/speculative/{branch}` | Speculative merge result for a specific branch against main (M13.5) |
 | `POST/GET` | `/api/v1/agents` | Register (returns auth_token) / list (`?status=`) |
 | `GET` | `/api/v1/agents/{id}` | Get agent |
 | `PUT` | `/api/v1/agents/{id}/status` | Update agent status |
@@ -121,6 +127,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `POST` | `/api/v1/agents/{id}/logs` | Append a log line to the agent's log buffer (M11.2) |
 | `GET` | `/api/v1/agents/{id}/logs` | Paginated agent log lines (`?limit=100&offset=0`) (M11.2) |
 | `GET` | `/api/v1/agents/{id}/logs/stream` | SSE live feed of new log lines for an agent (M11.2) |
+| `GET` | `/api/v1/agents/{id}/touched-paths` | All repo branches and file paths written to by this agent (M13.4) |
 | `GET` | `/ws/agents/{id}/tty` | WebSocket TTY attach — auth via first-message Bearer token; replays buffered logs then streams live PTY output (M11.2) |
 | `POST/GET` | `/api/v1/tasks` | Create / list (`?status=&assigned_to=&parent_task_id=`) |
 | `GET/PUT` | `/api/v1/tasks/{id}` | Read / update task |
@@ -277,6 +284,9 @@ See `crates/gyre-common/src/protocol.rs` for the full type definitions.
 {"type":"DomainEvent","event":"QueueUpdated"}
 {"type":"DomainEvent","event":"DataSeeded"}
 {"type":"DomainEvent","event":"PushRejected","repo_id":"<uuid>","branch":"<ref>","reason":"<gate-name>"}
+{"type":"DomainEvent","event":"SpeculativeConflict","repo_id":"<uuid>","branch":"<ref>"}
+{"type":"DomainEvent","event":"SpeculativeMergeClean","repo_id":"<uuid>","branch":"<ref>"}
+{"type":"DomainEvent","event":"HotFilesChanged","repo_id":"<uuid>"}
 ```
 
 The in-memory `ActivityStore` holds up to 1000 events (oldest dropped when full).

--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
 | M13: Forge Native | In Progress | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
 
-516 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+541 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications and [`AGENTS.md`](AGENTS.md) for the complete API and developer reference.


### PR DESCRIPTION
## Summary

Catches up AGENTS.md and README for PRs #80 (M13.4 + M13.5) and a missed endpoint row from PR #79's squash merge.

### PR #80 (M13.4 cross-agent code awareness — 4 new endpoints)
- `GET /api/v1/repos/{id}/blame?path={file}` — per-line agent attribution
- `GET /api/v1/repos/{id}/hot-files?limit=20` — files with most concurrent active agents (last 24h)
- `GET /api/v1/repos/{id}/review-routing?path={file}` — agents ranked by recency + commit count for review
- `GET /api/v1/agents/{id}/touched-paths` — all branches/paths an agent has written to

### PR #80 (M13.5 speculative merging — 2 new endpoints + 3 domain events)
- `GET /api/v1/repos/{id}/speculative` — list all speculative merge results
- `GET /api/v1/repos/{id}/speculative/{branch}` — result for specific branch
- `SpeculativeConflict` domain event — background job detected conflict
- `SpeculativeMergeClean` domain event — branch merges cleanly against main
- `HotFilesChanged` domain event — concurrent-agent file overlap changed

### PR #79 squash-merge gap (1 endpoint)
- `GET/PUT /api/v1/repos/{id}/push-gates` — the M13.1 push-gates endpoint row was silently dropped during the squash merge (pre-commit stash/restore cycle); recovering it here

### README
- Test count: 516 → 541 (PR #80 adds 25 new tests)

## Changes
- `AGENTS.md`: 8 new endpoint rows, 3 new domain event lines
- `README.md`: test count updated

🤖 DocGardener — automated documentation review