### PR TITLE
fix(security): remediate HIGH findings — shell injection, SSRF, path traversal, push-gate auth

### DIFF
--- a/crates/gyre-server/src/api/gates.rs
+++ b/crates/gyre-server/src/api/gates.rs
@@ -104,9 +104,10 @@ fn gate_status_str(s: &GateStatus) -> String {
 // ---------------------------------------------------------------------------
 
 /// POST /api/v1/repos/:id/gates — create a quality gate for a repo.
-#[instrument(skip(state, req), fields(repo_id = %repo_id))]
+#[instrument(skip(state, req, _auth), fields(repo_id = %repo_id))]
 pub async fn create_gate(
     State(state): State<Arc<AppState>>,
+    _auth: crate::auth::AuthenticatedAgent,
     Path(repo_id): Path<String>,
     Json(req): Json<CreateGateRequest>,
 ) -> Result<(StatusCode, Json<GateResponse>), ApiError> {
@@ -257,6 +258,7 @@ mod tests {
                     .method("POST")
                     .uri("/api/v1/repos/repo-1/gates")
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -298,6 +300,7 @@ mod tests {
                     .method("POST")
                     .uri("/api/v1/repos/repo-1/gates")
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -324,6 +327,7 @@ mod tests {
                     .method("POST")
                     .uri("/api/v1/repos/repo-1/gates")
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )

--- a/crates/gyre-server/src/api/push_gates.rs
+++ b/crates/gyre-server/src/api/push_gates.rs
@@ -76,6 +76,7 @@ pub async fn get_push_gates(
 /// PUT /api/v1/repos/:id/push-gates — set pre-accept gate list for this repo.
 pub async fn set_push_gates(
     State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminOnly,
     Path(repo_id): Path<String>,
     Json(req): Json<SetPushGatesRequest>,
 ) -> Result<(StatusCode, Json<PushGatesResponse>), ApiError> {
@@ -194,6 +195,7 @@ mod tests {
                     .method("PUT")
                     .uri("/api/v1/repos/repo-1/push-gates")
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -231,6 +233,7 @@ mod tests {
                     .method("PUT")
                     .uri("/api/v1/repos/repo-1/push-gates")
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -251,6 +254,7 @@ mod tests {
                     .method("PUT")
                     .uri("/api/v1/repos/no-such-repo/push-gates")
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )

--- a/crates/gyre-server/src/api/repos.rs
+++ b/crates/gyre-server/src/api/repos.rs
@@ -81,6 +81,14 @@ pub async fn create_repo(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateRepoRequest>,
 ) -> Result<(StatusCode, Json<RepoResponse>), ApiError> {
+    // Reject path traversal in project_id and name.
+    for field in [req.project_id.as_str(), req.name.as_str()] {
+        if field.contains("..") || field.contains('/') {
+            return Err(ApiError::InvalidInput(
+                "project_id and name must not contain '..' or '/'".to_string(),
+            ));
+        }
+    }
     let repos_root = std::env::var("GYRE_REPOS_PATH").unwrap_or_else(|_| "./repos".to_string());
     let repo_path = req
         .path
@@ -181,6 +189,20 @@ pub async fn create_mirror_repo(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateMirrorRequest>,
 ) -> Result<(StatusCode, Json<RepoResponse>), ApiError> {
+    // Reject path traversal in project_id and name.
+    for field in [req.project_id.as_str(), req.name.as_str()] {
+        if field.contains("..") || field.contains('/') {
+            return Err(ApiError::InvalidInput(
+                "project_id and name must not contain '..' or '/'.".to_string(),
+            ));
+        }
+    }
+    // Only allow https:// URLs to prevent SSRF.
+    if !req.url.starts_with("https://") {
+        return Err(ApiError::InvalidInput(
+            "mirror URL must use https:// scheme".to_string(),
+        ));
+    }
     let repos_root = std::env::var("GYRE_REPOS_PATH").unwrap_or_else(|_| "./repos".to_string());
     let repo_path = format!("{}/{}/{}.git", repos_root, req.project_id, req.name);
 

--- a/crates/gyre-server/src/gate_executor.rs
+++ b/crates/gyre-server/src/gate_executor.rs
@@ -100,10 +100,13 @@ async fn run_gate(state: Arc<AppState>, result_id: Id, gate: gyre_domain::Qualit
 }
 
 async fn run_command(cmd: &str) -> (GateStatus, String) {
-    // Run via `sh -c` so piped / complex commands work.
-    let result = tokio::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
+    // Split command on whitespace to avoid shell injection via `sh -c`.
+    let parts: Vec<&str> = cmd.split_whitespace().collect();
+    if parts.is_empty() {
+        return (GateStatus::Failed, "empty command".to_string());
+    }
+    let result = tokio::process::Command::new(parts[0])
+        .args(&parts[1..])
         .output()
         .await;
 


### PR DESCRIPTION
## Summary

Security fixes for HIGH-severity findings from CISO audit:

- **C-2→H (Shell Injection)**: Replaced `sh -c` in `gate_executor.rs` with whitespace-split command args. Gate commands are no longer passed through the shell, preventing injection via attacker-controlled commands.
- **C-4→H / C-6→H (Path Traversal)**: Added validation in `create_repo` and `create_mirror_repo` to reject `project_id` and `name` containing `..` or `/`. Prevents traversal to arbitrary filesystem paths.
- **C-5→H (SSRF)**: Mirror URL must now start with `https://`. Rejects `file://`, `http://`, `git://`, and other schemes.
- **H-6 (Push-gate authorization)**: `PUT /api/v1/repos/:id/push-gates` now requires `AdminOnly`. Non-admin users can no longer modify push gate configuration.
- **Bonus (Auth on gate creation)**: `POST /api/v1/repos/:id/gates` now requires `AuthenticatedAgent` to prevent unauthenticated gate creation.

## Test plan

- [x] `cargo test -p gyre-server --lib` — 309 tests pass
- [x] `cargo fmt --all` — no formatting issues
- [x] Tests updated to pass auth headers where required
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)