### PR TITLE
docs: document PR #82 security auth/validation constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,14 +106,14 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET/PUT/DELETE` | `/api/v1/projects/{id}` | Read / update / delete project |
 | `POST/GET` | `/api/v1/repos` | Create / list repos (`?project_id=`); response includes mirror fields (`is_mirror`, `mirror_url`, `mirror_interval_secs`, `last_mirror_sync`) (M12.2) |
 | `GET` | `/api/v1/repos/{id}` | Get repository (includes mirror fields) |
-| `POST` | `/api/v1/repos/mirror` | Create a pull mirror from an external git URL (bare clone + periodic background sync) (M12.2) |
+| `POST` | `/api/v1/repos/mirror` | Create a pull mirror from an external git URL (bare clone + periodic background sync); URL must use `https://` (M12.2) |
 | `POST` | `/api/v1/repos/{id}/mirror/sync` | Manually trigger a fetch sync on a mirror repo (M12.2) |
 | `GET` | `/api/v1/repos/{id}/branches` | List branches in repository |
 | `GET` | `/api/v1/repos/{id}/commits` | Commit log (`?branch=<name>&limit=50`) |
 | `GET` | `/api/v1/repos/{id}/diff` | Diff between refs (`?from=<ref>&to=<ref>`) |
-| `POST/GET` | `/api/v1/repos/{id}/gates` | Create / list quality gates for a repo (`GateType`: TestCommand, LintCommand, RequiredApprovals) (M12.1) |
+| `POST/GET` | `/api/v1/repos/{id}/gates` | Create (auth required) / list quality gates for a repo (`GateType`: TestCommand, LintCommand, RequiredApprovals) (M12.1) |
 | `DELETE` | `/api/v1/repos/{id}/gates/{gate_id}` | Delete a quality gate (M12.1) |
-| `GET/PUT` | `/api/v1/repos/{id}/push-gates` | Get / set active pre-accept push gates for a repo (built-in: ConventionalCommit, TaskRef, NoEmDash) (M13.1) |
+| `GET/PUT` | `/api/v1/repos/{id}/push-gates` | Get / set active pre-accept push gates for a repo (built-in: ConventionalCommit, TaskRef, NoEmDash); **PUT requires Admin role** (M13.1) |
 | `GET` | `/api/v1/repos/{id}/blame?path={file}` | Per-line agent attribution — which agent last touched each line (M13.4) |
 | `GET` | `/api/v1/repos/{id}/hot-files?limit=20` | Files with the most concurrent active agents in the last 24h (M13.4) |
 | `GET` | `/api/v1/repos/{id}/review-routing?path={file}` | Ordered list of agents to request review from, ranked by recency and commit count (M13.4) |


### PR DESCRIPTION
## Summary

Catches up AGENTS.md for three behavior-changing security fixes from PR #82 that developers need to know about.

### `POST /api/v1/repos/mirror` — HTTPS-only URLs
Mirror URL must start with `https://`. Schemes `http://`, `file://`, `git://` are now rejected (SSRF fix, C-5/C-6 from CISO audit). Callers using non-HTTPS mirror URLs will receive a 400 error.

### `POST /api/v1/repos/{id}/gates` — auth now required
Gate creation previously allowed unauthenticated callers. Now requires `AuthenticatedAgent`. Unauthenticated POST to this endpoint now returns 401.

### `PUT /api/v1/repos/{id}/push-gates` — Admin role required
Setting push gate configuration now requires the `Admin` role (H-6 from CISO audit). Developers and agents receive 403 on PUT. GET remains accessible to all authenticated users.

## Changes
- `AGENTS.md`: 3 endpoint descriptions updated with auth/validation notes

🤖 DocGardener — automated documentation review