### PR TITLE
docs: document PR #85 security changes — Admin gate creation, path field ignored

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,14 +104,14 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/activity` | Query activity log (`?since=&limit=&agent_id=&event_type=`) |
 | `POST/GET` | `/api/v1/projects` | Create / list projects |
 | `GET/PUT/DELETE` | `/api/v1/projects/{id}` | Read / update / delete project |
-| `POST/GET` | `/api/v1/repos` | Create / list repos (`?project_id=`); response includes mirror fields (`is_mirror`, `mirror_url`, `mirror_interval_secs`, `last_mirror_sync`) (M12.2) |
+| `POST/GET` | `/api/v1/repos` | Create / list repos (`?project_id=`); response includes mirror fields (`is_mirror`, `mirror_url`, `mirror_interval_secs`, `last_mirror_sync`). Note: `path` field in create body is ignored — path is always server-computed as `{repos_root}/{project_id}/{name}.git` (M12.2) |
 | `GET` | `/api/v1/repos/{id}` | Get repository (includes mirror fields) |
 | `POST` | `/api/v1/repos/mirror` | Create a pull mirror from an external git URL (bare clone + periodic background sync); URL must use `https://` (M12.2) |
 | `POST` | `/api/v1/repos/{id}/mirror/sync` | Manually trigger a fetch sync on a mirror repo (M12.2) |
 | `GET` | `/api/v1/repos/{id}/branches` | List branches in repository |
 | `GET` | `/api/v1/repos/{id}/commits` | Commit log (`?branch=<name>&limit=50`) |
 | `GET` | `/api/v1/repos/{id}/diff` | Diff between refs (`?from=<ref>&to=<ref>`) |
-| `POST/GET` | `/api/v1/repos/{id}/gates` | Create (auth required) / list quality gates for a repo (`GateType`: TestCommand, LintCommand, RequiredApprovals) (M12.1) |
+| `POST/GET` | `/api/v1/repos/{id}/gates` | Create (**Admin required**) / list quality gates for a repo (`GateType`: TestCommand, LintCommand, RequiredApprovals) (M12.1) |
 | `DELETE` | `/api/v1/repos/{id}/gates/{gate_id}` | Delete a quality gate (M12.1) |
 | `GET/PUT` | `/api/v1/repos/{id}/push-gates` | Get / set active pre-accept push gates for a repo (built-in: ConventionalCommit, TaskRef, NoEmDash); **PUT requires Admin role** (M13.1) |
 | `GET` | `/api/v1/repos/{id}/blame?path={file}` | Per-line agent attribution — which agent last touched each line (M13.4) |


### PR DESCRIPTION
## Summary

Catches up AGENTS.md for two behavior-changing security fixes from PR #85 that break existing callers silently or with unexpected status codes.

### `POST /api/v1/repos/{id}/gates` — escalated to **Admin only**
PR #83 documented this as "auth required" (based on PR #82's change from unauthenticated). PR #85 (C-2 residual) escalates further to `AdminOnly`. Non-admin authenticated agents now receive **403**, not 401. Updates the note from "auth required" → "Admin required".

### `POST /api/v1/repos` — `path` field silently ignored (C-4 fix)
The create-repo request body previously accepted an optional `path` field for a custom on-disk repository location. PR #85 removes this as a path traversal vector: the field is now accepted in JSON but **silently discarded**. The path is always computed server-side as `{repos_root}/{project_id}/{name}.git`. Callers who relied on custom paths will need to know this changed.

## Changes
- `AGENTS.md`: 2 endpoint descriptions updated

🤖 DocGardener — automated documentation review