### PR TITLE
docs: note mirror_url credential redaction in repo responses (H-5, PR #87)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/activity` | Query activity log (`?since=&limit=&agent_id=&event_type=`) |
 | `POST/GET` | `/api/v1/projects` | Create / list projects |
 | `GET/PUT/DELETE` | `/api/v1/projects/{id}` | Read / update / delete project |
-| `POST/GET` | `/api/v1/repos` | Create / list repos (`?project_id=`); response includes mirror fields (`is_mirror`, `mirror_url`, `mirror_interval_secs`, `last_mirror_sync`). Note: `path` field in create body is ignored — path is always server-computed as `{repos_root}/{project_id}/{name}.git` (M12.2) |
-| `GET` | `/api/v1/repos/{id}` | Get repository (includes mirror fields) |
+| `POST/GET` | `/api/v1/repos` | Create / list repos (`?project_id=`); response includes mirror fields (`is_mirror`, `mirror_url`, `mirror_interval_secs`, `last_mirror_sync`). `mirror_url` has credentials redacted (`https://***@host`); `path` in create body is ignored — server-computed as `{repos_root}/{project_id}/{name}.git` (M12.2) |
+| `GET` | `/api/v1/repos/{id}` | Get repository (includes mirror fields); `mirror_url` has credentials redacted (H-5) |
 | `POST` | `/api/v1/repos/mirror` | Create a pull mirror from an external git URL (bare clone + periodic background sync); URL must use `https://` (M12.2) |
 | `POST` | `/api/v1/repos/{id}/mirror/sync` | Manually trigger a fetch sync on a mirror repo (M12.2) |
 | `GET` | `/api/v1/repos/{id}/branches` | List branches in repository |


### PR DESCRIPTION
## Summary

Documents the H-5 security fix from PR #87: `mirror_url` now has embedded credentials redacted in all repository API responses.

### Breaking change for API consumers

Any caller that stored, compared, or re-used the raw `mirror_url` value from repo responses will see a different format after PR #87. A URL like:
```
https://ghp_token123@github.com/org/repo.git
```
is now returned as:
```
https://***@github.com/org/repo.git
```

### Affected endpoints
- `GET /api/v1/repos/{id}` — all repo GET responses
- `POST/GET /api/v1/repos` — list and create responses
- `POST /api/v1/repos/mirror` — create mirror response (the URL you just submitted is redacted in the response)

## Changes
- `AGENTS.md`: 2 endpoint descriptions updated with H-5 credential redaction note

## Note on PR #86 CI
PR #86 (which this PR is independent of) has a CI failure caused by a pre-existing E2E test regression from PR #85, not from doc changes. CEO has been notified to fix `e2e_ralph_loop.rs`. This PR's CI may fail for the same reason until that's fixed.

🤖 DocGardener — automated documentation review