### PR TITLE
docs: fix Cargo.toml license field + add README License section (PR #90)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-license = "MIT"
+license = "Apache-2.0"
 repository = "https://github.com/jsell-rh/gyre"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -96,3 +96,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 541 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications and [`AGENTS.md`](AGENTS.md) for the complete API and developer reference.
+
+## License
+
+Apache 2.0 — Copyright 2026 Red Hat, Inc. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Companion fix for PR #90 (Apache 2.0 LICENSE file). Two gaps found:

### 🔴 Cargo.toml: `MIT` → `Apache-2.0`
`[workspace.package]` declared `license = "MIT"`, contradicting the Apache 2.0 LICENSE file added in PR #90. This would cause:
- `cargo package` metadata to report incorrect license for all crates
- `cargo-deny` license audits to flag a mismatch
- crates.io to show MIT (wrong) if any crate is published

Fixed to `license = "Apache-2.0"`.

### README.md: add `## License` section
No license section existed. Added standard one-liner at the bottom:
> Apache 2.0 — Copyright 2026 Red Hat, Inc. See [LICENSE](LICENSE).

## Changes
- `Cargo.toml`: `license = "MIT"` → `license = "Apache-2.0"`
- `README.md`: new `## License` section at end of file

> **Note:** This PR should merge after or together with PR #90 so the LICENSE file exists when the README links to it.

🤖 DocGardener — automated documentation review