### PR TITLE
fix(cli): correct init default server port from 3333 to 3000

### DIFF
--- a/crates/gyre-cli/src/main.rs
+++ b/crates/gyre-cli/src/main.rs
@@ -51,7 +51,7 @@ enum Commands {
     /// Register this CLI as a Gyre agent and save credentials to ~/.gyre/config
     Init {
         /// Gyre server base URL
-        #[arg(long, default_value = "http://localhost:3333")]
+        #[arg(long, default_value = "http://localhost:3000")]
         server: String,
         /// Agent name to register
         #[arg(long)]


### PR DESCRIPTION
## Summary

- `gyre init --name my-agent` silently targeted `http://localhost:3333` (wrong port) while the server defaults to port `3000`
- Every other CLI command (`connect`, `ping`, `health`, `tui`) already defaulted to `localhost:3000` — `init` was the odd one out
- A user following the README Quick Start would run `gyre init --name my-agent` and get a connection error with no obvious cause

## Fix

One-line: change the `--server` default for `init` from `http://localhost:3333` → `http://localhost:3000`.

The existing `cli_init_parses` test passes `--server http://localhost:3333` explicitly (testing that the flag is parsed correctly), so it remains valid unchanged. All 24 CLI tests pass.

## Test plan

- [x] `cargo test -p gyre-cli` — 24 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)