### PR TITLE
docs: document M-8 SHA validation; fix stale C-1 spawn fields in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `POST` | `/api/v1/agents/{id}/complete` | Complete agent: open MR, mark task done, clean up worktree |
 | `GET` | `/git/{project}/{repo}/info/refs` | Smart HTTP git discovery (`?service=git-upload-pack` or `git-receive-pack`) |
 | `POST` | `/git/{project}/{repo}/git-upload-pack` | Smart HTTP git clone / fetch data |
-| `POST` | `/git/{project}/{repo}/git-receive-pack` | Smart HTTP git push data + post-receive hook |
+| `POST` | `/git/{project}/{repo}/git-receive-pack` | Smart HTTP git push data + post-receive hook; SHA values in ref-updates must be valid 40-char hex — non-hex SHAs rejected to prevent argument injection (M-8) |
 | `POST` | `/api/v1/auth/api-keys` | Create API key (Admin role required; returns `gyre_<uuid>` key) |
 | `GET` | `/metrics` | Prometheus metrics (request count, duration, active agents, merge queue depth) |
 | `GET` | `/api/v1/admin/health` | Admin: server uptime + agent/task/project counts (Admin only) |
@@ -408,9 +408,8 @@ Agents are created in dependency order (parents before children). Parent links a
   "repo_id": "<repo-uuid>",
   "task_id": "<task-uuid>",
   "branch": "feat/my-feature",
-  "parent_id": "<orchestrator-agent-uuid>",  // optional
-  "command": "claude",                        // optional — process to launch (M11.1)
-  "command_args": ["--task", "<task-uuid>"]   // optional — args for command (M11.1)
+  "parent_id": "<orchestrator-agent-uuid>",    // optional
+  "compute_target_id": "<target-uuid>"         // optional — remote compute target
 }
 
 // Response 201


### PR DESCRIPTION
## Summary

Two correctness fixes to `AGENTS.md` covering recently merged security PRs:

**1. git-receive-pack — M-8 SHA validation (PR #93)**

Added a security note to the `POST /git/{project}/{repo}/git-receive-pack` endpoint row:
> SHA values in ref-updates must be valid 40-char hex — non-hex SHAs rejected to prevent argument injection (M-8)

Agents writing custom git push clients need to know malformed SHAs will be rejected at the server.

**2. Spawn request body — stale C-1 fields (PR #78)**

The `POST /api/v1/agents/spawn` request body example still showed `command` and `command_args` fields that were removed in the C-1 RCE security fix. Those fields no longer exist in `SpawnAgentRequest`. Fixed by:
- Removing `"command"` and `"command_args"` from the JSON example
- Adding `"compute_target_id"` (the `Option<String>` field that IS in the struct)

## Test plan

- [x] Both changes are doc-only — no code affected
- [x] Verified against `crates/gyre-server/src/api/spawn.rs` `SpawnAgentRequest` struct (6 fields, no command/command_args)
- [x] Verified against `crates/gyre-server/src/git_http.rs` `is_valid_sha` function (40-char hex check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)