### PR TITLE
docs: add M14 Supply Chain Security to milestone tables (PR #95)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -623,6 +623,7 @@ Key specs to read before making changes:
 | M11 milestone deliverables | [specs/milestones/m11-agent-execution.md](specs/milestones/m11-agent-execution.md) |
 | M12 milestone deliverables | [specs/milestones/m12-quality-gates.md](specs/milestones/m12-quality-gates.md) |
 | M13 milestone deliverables | [specs/milestones/m13-forge-native.md](specs/milestones/m13-forge-native.md) |
+| M14 milestone deliverables | [specs/milestones/m14-supply-chain.md](specs/milestones/m14-supply-chain.md) |
 | Forge-native advantages | [specs/system/forge-advantages.md](specs/system/forge-advantages.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M11: Agent Execution | Done | Real agent processes, TTY attach, agent logs, execution lifecycle |
 | M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
 | M13: Forge Native | In Progress | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
+| M14: Supply Chain Security | Planned | Agent stack fingerprinting, push attestation, AIBOM generation |
 
 541 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -78,6 +78,7 @@ How Gyre gets built - process and standards for the agent team.
 | M11: Agent Execution | [`milestones/m11-agent-execution.md`](milestones/m11-agent-execution.md) | Real agent processes, TTY attach from browser, agent logs |
 | M12: Quality Gates | [`milestones/m12-quality-gates.md`](milestones/m12-quality-gates.md) | Merge queue gates (tests/lints/reviews), repo mirroring, diff viewer |
 | M13: Forge Native | [`milestones/m13-forge-native.md`](milestones/m13-forge-native.md) | Pre-accept validation, commit provenance, speculative merging, cross-agent awareness |
+| M14: Supply Chain Security | [`milestones/m14-supply-chain.md`](milestones/m14-supply-chain.md) | Agent stack fingerprinting, push attestation, AIBOM generation |
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

PR #95 added `specs/milestones/m14-supply-chain.md` but three milestone index locations were not updated:

| File | Gap |
|---|---|
| `README.md` | `## Current Status` table stopped at M13 |
| `AGENTS.md` | `## Architecture Decisions` spec links stopped at M13 |
| `specs/index.md` | Milestones table stopped at M13 |

All three now include:
> M14: Supply Chain Security — Agent stack fingerprinting, push attestation, AIBOM generation

**Note:** I also spotted `crates/gyre-server/src/api/aibom.rs` and the `GET /api/v1/repos/{id}/aibom` route in `mod.rs` already in the working tree (CEO's in-progress M14 implementation). AGENTS.md endpoint table will be updated when that code lands in a PR.

## Test plan

- [x] Doc-only changes — no code affected
- [x] Verified M14 spec path: `specs/milestones/m14-supply-chain.md` exists on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)