### PR TITLE
fix(docs): replace nonexistent GYRE_DB_PATH with GYRE_DATABASE_URL in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,11 +83,11 @@ Requires `git` on `PATH`. Test binds to `127.0.0.1:0` (random port) so runs safe
 ## Running the Server
 
 ```bash
-# Dev mode (defaults: port 3000, token gyre-dev-token, db gyre.db)
+# Dev mode (defaults: port 3000, token gyre-dev-token, in-memory DB)
 cargo run -p gyre-server
 
 # With custom settings
-GYRE_PORT=8080 GYRE_AUTH_TOKEN=my-token GYRE_DB_PATH=/tmp/gyre.db RUST_LOG=debug \
+GYRE_PORT=8080 GYRE_AUTH_TOKEN=my-token GYRE_DATABASE_URL=sqlite:///tmp/gyre.db RUST_LOG=debug \
   cargo run -p gyre-server
 
 # Release build
@@ -237,7 +237,6 @@ The git HTTP endpoints (`/git/...`) accept all four auth mechanisms so that `gyr
 |----------|---------|-------------|
 | `GYRE_PORT` | `3000` | TCP port to listen on |
 | `GYRE_AUTH_TOKEN` | `gyre-dev-token` | Bearer token clients must send to authenticate |
-| `GYRE_DB_PATH` | `gyre.db` | SQLite database file path |
 | `GYRE_BASE_URL` | `http://localhost:<port>` | Public base URL (used in clone URLs returned by spawn API) |
 | `GYRE_LOG_FORMAT` | _(human-readable)_ | Set to `json` for structured JSON log output (M4.1) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(disabled)_ | OTLP/gRPC collector URL, e.g. `http://otel-collector:4317` (M4.1) |


### PR DESCRIPTION
## Summary

`GYRE_DB_PATH` does not exist anywhere in the server codebase — `grep -rn "GYRE_DB_PATH" crates/` returns nothing. The server reads `GYRE_DATABASE_URL` (e.g. `sqlite://gyre.db`) via `std::env::var("GYRE_DATABASE_URL")` in `crates/gyre-server/src/lib.rs:319`.

AGENTS.md had two stale references to the fictional variable:

1. **Run example** (line 90): `GYRE_DB_PATH=/tmp/gyre.db` → `GYRE_DATABASE_URL=sqlite:///tmp/gyre.db`
2. **Env var table** (line 245): `| GYRE_DB_PATH | gyre.db | SQLite database file path |` — row deleted (the correct `GYRE_DATABASE_URL` row already exists below it)
3. **Comment** (line 86): "db gyre.db" → "in-memory DB" — when `GYRE_DATABASE_URL` is unset the server uses in-memory stores (stateless)

README.md was already correct and uses `GYRE_DATABASE_URL` throughout.

## Impact

Any agent or human following the AGENTS.md "With custom settings" example would set a variable that has no effect, silently leaving the server in stateless in-memory mode rather than persisting to a file.

## Test plan
- [ ] Verify `grep -rn "GYRE_DB_PATH" crates/` returns nothing (the var doesn't exist)
- [ ] Verify the run example now uses `GYRE_DATABASE_URL=sqlite:///tmp/gyre.db`
- [ ] Verify the stale table row is removed

🤖 DocGardener — autonomous documentation review agent