### PR TITLE
docs(readme): clarify Quick Start UX for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@ Open **http://localhost:3000** — the dashboard loads immediately. Default auth
 Seed demo data to explore the UI:
 ```bash
 curl -s -X POST http://localhost:3000/api/v1/admin/seed \
-  -H "Authorization: Bearer gyre-dev-token" | jq .
+  -H "Authorization: Bearer gyre-dev-token"
 ```
+_(Pipe through `jq .` for pretty output if you have jq installed.)_
 
 ## CLI
+
+The CLI commands below require the server to be running. `gyre init` registers
+this CLI instance and saves credentials to `~/.gyre/config`; all other commands
+use those saved credentials automatically.
 
 ```bash
 # Register as a named agent (saves token + agent ID to ~/.gyre/config)
@@ -39,7 +44,7 @@ curl -s -X POST http://localhost:3000/api/v1/admin/seed \
 # List tasks
 ./target/release/gyre tasks list
 
-# Clone a repo hosted by Gyre
+# Clone a repo hosted by Gyre (use project/repo names from the dashboard)
 ./target/release/gyre clone myproject/myrepo
 ```
 


### PR DESCRIPTION
## Summary

Three small usability fixes for humans following the README (per operator directive: README should be "100% easy to follow to get the app up and running").

### 1. Remove implicit jq dependency from seed command
The seed command used `| jq .` but `jq` is not listed in Prerequisites. A user without jq installed would see a broken-pipe error even though the seed API call succeeds. Fixed by removing `| jq .` from the command and adding a note that jq is optional for pretty-printing.

**Before:**
```bash
curl -s -X POST http://localhost:3000/api/v1/admin/seed \
  -H "Authorization: Bearer gyre-dev-token" | jq .
```
**After:**
```bash
curl -s -X POST http://localhost:3000/api/v1/admin/seed \
  -H "Authorization: Bearer gyre-dev-token"
```
_(Pipe through `jq .` for pretty output if you have jq installed.)_

### 2. Clarify CLI credential flow
Added a sentence explaining that the server must be running and that `gyre init` saves credentials used by all subsequent commands. Without this, a user might run `gyre tasks list` before `gyre init` and get a confusing "config not found" error.

### 3. `gyre clone` placeholder comment
Added "(use project/repo names from the dashboard)" to the clone command comment, making clear that `myproject/myrepo` is a placeholder and where to find real names.

## Test plan
- [ ] Follow Quick Start without jq installed: curl seed command completes without error
- [ ] Follow CLI section in order: init → health → tasks → clone flows correctly
- [ ] No functional behavior changes; docs only

🤖 DocGardener — autonomous documentation review agent