### PR TITLE
docs: document vitest frontend tests added in PR #106

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,11 @@ cargo build --all
 # Build release binaries
 cargo build --release -p gyre-server -p gyre-cli
 
-# Run all tests
+# Run all Rust tests
 cargo test --all
+
+# Run frontend component tests (vitest — requires Node/npm)
+cd web && npm test && cd ..
 
 # Format check
 cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M13: Forge Native | In Progress | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
 | M14: Supply Chain Security | In Progress | Agent stack fingerprinting, push attestation, AIBOM generation |
 
-554 tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+554 Rust + 31 frontend component tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications and [`AGENTS.md`](AGENTS.md) for the complete API and developer reference.
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -45,6 +45,7 @@ How Gyre gets built - process and standards for the agent team.
 | Agent Development Workflow | [`development/agent-workflow.md`](development/agent-workflow.md) | Immediate feedback, worktrees, PRs, fix the environment |
 | Dogfooding | [`development/dogfooding.md`](development/dogfooding.md) | Building Gyre with agent-boss |
 | Development Philosophy | [`development/philosophy.md`](development/philosophy.md) | Speed, failure domains, humans steer / agents execute |
+| Frontend Testing | [`development/frontend-testing.md`](development/frontend-testing.md) | Vitest + Testing Library component tests, jsdom setup, build gate |
 
 ## Prior Art & Lessons Learned
 


### PR DESCRIPTION
## Summary

PR #106 (`feat(web): vitest component tests + build gate`) added 31 vitest component tests and a new `specs/development/frontend-testing.md` spec, but left three documentation locations un-updated.

**Gaps fixed:**

### 1. `specs/index.md` — Frontend Testing entry missing
PR #106 added `specs/development/frontend-testing.md` (110 lines) but did not index it. Added row to the Development specs table:
> `| Frontend Testing | development/frontend-testing.md | Vitest + Testing Library component tests, jsdom setup, build gate |`

### 2. `README.md` — test count stale
README said `554 tests passing` — does not reflect the 31 vitest tests that are now part of the CI build gate. Updated to:
> `554 Rust + 31 frontend component tests passing`

### 3. `AGENTS.md` Key Commands — `npm test` missing
Agents working on the web UI need to know how to run frontend tests. Added:
```bash
# Run frontend component tests (vitest — requires Node/npm)
cd web && npm test && cd ..
```

## Test plan
- [ ] `grep "frontend-testing" specs/index.md` returns table row
- [ ] `grep "31 frontend" README.md` returns updated test count line
- [ ] `grep "npm test" AGENTS.md` returns key command entry

🤖 DocGardener — autonomous documentation review agent