### PR TITLE
docs: add M15 Diesel ORM to milestone tables + fix GYRE_DATABASE_URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ The git HTTP endpoints (`/git/...`) accept all four auth mechanisms so that `gyr
 | `GYRE_RATE_LIMIT` | `100` | Requests per second allowed per IP before 429 (M7.3) |
 | `GYRE_AUDIT_SIMULATE` | _(disabled)_ | Set to `true` to run the audit event simulator on startup (M7.1) |
 | `GYRE_REPOS_PATH` | `./repos/` | Directory for bare git repositories on disk. Created on startup if absent. (M10.3) |
-| `GYRE_DATABASE_URL` | _(unset — in-memory)_ | SQLite database URL, e.g. `sqlite://gyre.db`. When set, all 16 port traits persist to SQLite with WAL mode. Unset = in-memory (default, stateless). (M10.1) |
+| `GYRE_DATABASE_URL` | _(unset — in-memory)_ | SQLite database URL, e.g. `sqlite://gyre.db`. When set, all port traits persist to SQLite with WAL mode; Diesel runs pending migrations automatically on startup. Unset = in-memory (default, stateless). (M10.1, M15.1) |
 
 ### WebSocket Protocol (`gyre-common::WsMessage`)
 
@@ -630,6 +630,8 @@ Key specs to read before making changes:
 | M12 milestone deliverables | [specs/milestones/m12-quality-gates.md](specs/milestones/m12-quality-gates.md) |
 | M13 milestone deliverables | [specs/milestones/m13-forge-native.md](specs/milestones/m13-forge-native.md) |
 | M14 milestone deliverables | [specs/milestones/m14-supply-chain.md](specs/milestones/m14-supply-chain.md) |
+| M15 milestone deliverables | [specs/milestones/m15-diesel-migrations.md](specs/milestones/m15-diesel-migrations.md) |
+| Database & Migrations | [specs/development/database-migrations.md](specs/development/database-migrations.md) |
 | Forge-native advantages | [specs/system/forge-advantages.md](specs/system/forge-advantages.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
 | M13: Forge Native | In Progress | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
 | M14: Supply Chain Security | In Progress | Agent stack fingerprinting, push attestation, AIBOM generation |
+| M15: Diesel ORM | In Progress | Diesel ORM + migrations, full SQLite persistence, multi-tenancy (tenant_id scoping) |
 
 554 Rust + 31 frontend component tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -81,6 +81,7 @@ How Gyre gets built - process and standards for the agent team.
 | M12: Quality Gates | [`milestones/m12-quality-gates.md`](milestones/m12-quality-gates.md) | Merge queue gates (tests/lints/reviews), repo mirroring, diff viewer |
 | M13: Forge Native | [`milestones/m13-forge-native.md`](milestones/m13-forge-native.md) | Pre-accept validation, commit provenance, speculative merging, cross-agent awareness |
 | M14: Supply Chain Security | [`milestones/m14-supply-chain.md`](milestones/m14-supply-chain.md) | Agent stack fingerprinting, push attestation, AIBOM generation |
+| M15: Diesel ORM | [`milestones/m15-diesel-migrations.md`](milestones/m15-diesel-migrations.md) | Diesel ORM + migrations, full SQLite persistence, multi-tenancy |
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

PR #102 was closed without merging. This re-applies those changes cleanly on current main (after PRs #104–#109 landed).

- **README.md**: Add M15 row to Current Status table (`In Progress` — Diesel ORM, migrations, multi-tenancy)
- **specs/index.md**: Add M15 milestone row pointing to `milestones/m15-diesel-migrations.md`
- **AGENTS.md**: Add M15 + Database & Migrations rows to Architecture Decisions table
- **AGENTS.md**: Fix `GYRE_DATABASE_URL` description — remove stale "all 16 port traits" count, add note that Diesel runs pending migrations automatically on startup (M15.1)

## Gaps covered

| Merged PR | Gap |
|---|---|
| #104 M15.1 Diesel ORM foundation | M15 not in milestone tables |
| #105 M15.2 complete Diesel migration | GYRE_DATABASE_URL docs stale |
| #109 M15.3 multi-tenancy | database-migrations spec not linked in Architecture Decisions |

## Test plan

- [x] `cargo fmt --all -- --check` passes (doc-only change)
- [x] No spec/code files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)