### PR TITLE
docs: agent-gates in AGENTS.md + Diesel ORM in README tech stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -615,6 +615,7 @@ Key specs to read before making changes:
 |---|---|
 | Tech stack + hexagonal invariants | [specs/development/architecture.md](specs/development/architecture.md) |
 | Design principles (invariants) | [specs/system/design-principles.md](specs/system/design-principles.md) |
+| Agent Gates & Spec Binding | [specs/system/agent-gates.md](specs/system/agent-gates.md) |
 | M0 milestone deliverables | [specs/milestones/m0-walking-skeleton.md](specs/milestones/m0-walking-skeleton.md) |
 | M1 milestone deliverables | [specs/milestones/m1-domain-foundation.md](specs/milestones/m1-domain-foundation.md) |
 | M2 milestone deliverables | [specs/milestones/m2-source-control.md](specs/milestones/m2-source-control.md) |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 
 - **Rust** - server, CLI, agent runtime
 - **Svelte 5 + shadcn-svelte** - web UI (pre-built, no Node required to run)
-- **SQLite** - default storage; WAL mode, full persistence when `GYRE_DATABASE_URL` is set
+- **SQLite + Diesel ORM** - default storage; WAL mode, type-safe queries, auto-migrations, full persistence when `GYRE_DATABASE_URL` is set
 - **NixOS** - single definition builds server, Docker image, QEMU VM, LXC container
 - **WireGuard** - agent networking mesh
 


### PR DESCRIPTION
## Summary

Two documentation gaps from PRs #111 and #112:

### Gap 1 — PR #112 (agent-gates spec)
`AGENTS.md` Architecture Decisions table was missing `specs/system/agent-gates.md`.

This spec introduces **mandatory spec-to-code cryptographic binding**: every MR must reference a spec by path + git SHA, and the forge verifies at merge time that the spec exists, is approved, and hasn't been superseded. Any agent building features needs to know this before opening a branch. Added alongside `Design principles` at the top of the Architecture Decisions table.

### Gap 2 — PR #111 (M15 server wiring, rusqlite removed)
README Tech Stack listed `SQLite` without mentioning Diesel. After M15.1–M15.4, rusqlite is fully removed from the codebase. Diesel ORM is the exclusive persistence layer (type-safe queries, auto-migrations). Updated to `SQLite + Diesel ORM`.

## Files changed

| File | Change |
|---|---|
| `AGENTS.md` | +1 row: Agent Gates & Spec Binding → `specs/system/agent-gates.md` |
| `README.md` | Tech Stack: `SQLite` → `SQLite + Diesel ORM` |

## Test plan

- [x] `cargo fmt --all -- --check` passes (doc-only change)
- [x] Links point to files that exist on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)