### PR TITLE
feat(server): M13.6 write custom git refs on agent lifecycle events

### DIFF
--- a/crates/gyre-server/src/api/spawn.rs
+++ b/crates/gyre-server/src/api/spawn.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::instrument;
 
-use crate::{auth::AuthenticatedAgent, AppState};
+use crate::{auth::AuthenticatedAgent, git_refs, AppState};
 
 use super::agents::AgentResponse;
 use super::error::ApiError;
@@ -116,6 +116,14 @@ pub async fn spawn_agent(
         .await
     {
         tracing::warn!("create_worktree failed: {e}");
+    }
+
+    // Write custom ref namespaces (best-effort)
+    if let Some(sha) = git_refs::resolve_ref(&repo.path, "HEAD").await {
+        let agent_ref = format!("refs/agents/{}/head", agent.id);
+        let ralph_ref = format!("refs/ralph/{}/implement", task.id);
+        git_refs::write_ref(&repo.path, &agent_ref, &sha).await;
+        git_refs::write_ref(&repo.path, &ralph_ref, &sha).await;
     }
 
     // Record worktree in DB linked to agent and task
@@ -284,6 +292,17 @@ pub async fn complete_agent(
     // Transition agent to Idle
     let _ = agent.transition_status(AgentStatus::Idle);
     state.agents.update(&agent).await?;
+
+    // Write snapshot ref for this agent (best-effort)
+    if let Ok(Some(repo)) = state.repos.find_by_id(&mr.repository_id).await {
+        let snap_prefix = format!("refs/agents/{}/snapshots/", agent.id);
+        let n = git_refs::count_refs_under(&repo.path, &snap_prefix).await;
+        let snap_ref = format!("refs/agents/{}/snapshots/{}", agent.id, n);
+        let branch_ref = format!("refs/heads/{}", mr.source_branch);
+        if let Some(sha) = git_refs::resolve_ref(&repo.path, &branch_ref).await {
+            git_refs::write_ref(&repo.path, &snap_ref, &sha).await;
+        }
+    }
 
     // Auto-track agent completion
     let ev = AnalyticsEvent::new(

--- a/crates/gyre-server/src/git_refs.rs
+++ b/crates/gyre-server/src/git_refs.rs
@@ -1,0 +1,81 @@
+//! Helpers for reading and writing custom git ref namespaces.
+//!
+//! All operations are best-effort: errors are logged but never propagated to
+//! callers, so a missing repo or missing commit never fails an API request.
+
+use tokio::process::Command;
+
+/// Validate a refname: must not contain `..` and must not start with `-`.
+fn refname_safe(refname: &str) -> bool {
+    !refname.contains("..") && !refname.starts_with('-')
+}
+
+/// Resolve `refname` in `repo_path` to its SHA-1, or `None` if it doesn't exist.
+pub async fn resolve_ref(repo_path: &str, refname: &str) -> Option<String> {
+    if !refname_safe(refname) {
+        tracing::warn!(refname, "resolve_ref: unsafe refname rejected");
+        return None;
+    }
+    let out = Command::new("git")
+        .args(["rev-parse", "--verify", refname])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .ok()?;
+    if out.status.success() {
+        let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Some(sha);
+        }
+    }
+    None
+}
+
+/// Write (or update) `refname` in `repo_path` to point to `sha`.
+pub async fn write_ref(repo_path: &str, refname: &str, sha: &str) {
+    if !refname_safe(refname) {
+        tracing::warn!(refname, "write_ref: unsafe refname rejected");
+        return;
+    }
+    // Validate sha is 40-char hex to prevent argument injection
+    if sha.len() != 40 || !sha.chars().all(|c| c.is_ascii_hexdigit()) {
+        tracing::warn!(sha, refname, "write_ref: invalid SHA, skipping");
+        return;
+    }
+    let status = Command::new("git")
+        .args(["update-ref", "--", refname, sha])
+        .current_dir(repo_path)
+        .status()
+        .await;
+    match status {
+        Ok(s) if s.success() => {
+            tracing::debug!(refname, sha, "wrote custom ref");
+        }
+        Ok(s) => {
+            tracing::warn!(refname, sha, exit_code = ?s.code(), "write_ref: git update-ref failed");
+        }
+        Err(e) => {
+            tracing::warn!(refname, sha, error = %e, "write_ref: failed to run git");
+        }
+    }
+}
+
+/// Count refs that exist under `prefix` (e.g. `refs/agents/{id}/snapshots/`).
+pub async fn count_refs_under(repo_path: &str, prefix: &str) -> usize {
+    if !refname_safe(prefix) {
+        tracing::warn!(prefix, "count_refs_under: unsafe prefix rejected");
+        return 0;
+    }
+    let out = Command::new("git")
+        .args(["for-each-ref", "--format=%(refname)", prefix])
+        .current_dir(repo_path)
+        .output()
+        .await;
+    match out {
+        Ok(o) if o.status.success() => {
+            let text = String::from_utf8_lossy(&o.stdout);
+            text.lines().filter(|l| !l.is_empty()).count()
+        }
+        _ => 0,
+    }
+}

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod auth;
 pub mod domain_events;
 pub mod gate_executor;
 pub(crate) mod git_http;
+pub mod git_refs;
 pub(crate) mod health;
 pub mod jobs;
 pub(crate) mod mcp;


### PR DESCRIPTION
## Summary

Implements M13.6: Custom Ref Namespaces — write refs on lifecycle events.

- **New module** `crates/gyre-server/src/git_refs.rs` with three async helpers:
  - `resolve_ref(repo_path, refname)` — `git rev-parse --verify` a ref
  - `write_ref(repo_path, refname, sha)` — `git update-ref` to write/update a named ref
  - `count_refs_under(repo_path, prefix)` — count refs under a namespace prefix using `git for-each-ref`
- **Spawn handler**: after worktree creation, writes:
  - `refs/agents/{agent-id}/head` → HEAD SHA at spawn time
  - `refs/ralph/{task-id}/implement` → same SHA
- **Complete handler**: after agent transitions to Idle, writes:
  - `refs/agents/{agent-id}/snapshots/{n}` → branch tip SHA at completion

All git operations are best-effort (warn-on-failure, never fatal to the request).
Refnames validated to reject `..` and leading `-` to prevent argument injection.

## Test plan
- [x] `cargo build -p gyre-server` — clean build
- [x] `cargo test -p gyre-server --lib` — 318 tests pass (1 pre-existing CORS test failure on origin/main unrelated to this PR)
- [x] `cargo fmt --all` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)