### PR TITLE
docs(agents): document M13.6 custom git ref namespaces (refs/agents/, refs/ralph/)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,8 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/repos/{id}/agent-commits` | Query commits by agent (`?agent_id=`) |
 | `POST/GET` | `/api/v1/repos/{id}/worktrees` | Create / list worktrees |
 | `DELETE` | `/api/v1/repos/{id}/worktrees/{wt_id}` | Delete worktree |
-| `POST` | `/api/v1/agents/spawn` | Spawn agent: create record, generate token, provision worktree, assign task |
-| `POST` | `/api/v1/agents/{id}/complete` | Complete agent: open MR, mark task done, clean up worktree |
+| `POST` | `/api/v1/agents/spawn` | Spawn agent: create record, generate token, provision worktree, assign task; writes `refs/agents/{id}/head` and `refs/ralph/{task-id}/implement` (M13.6) |
+| `POST` | `/api/v1/agents/{id}/complete` | Complete agent: open MR, mark task done, clean up worktree; writes `refs/agents/{id}/snapshots/{n}` snapshot ref (M13.6) |
 | `GET` | `/git/{project}/{repo}/info/refs` | Smart HTTP git discovery (`?service=git-upload-pack` or `git-receive-pack`) |
 | `POST` | `/git/{project}/{repo}/git-upload-pack` | Smart HTTP git clone / fetch data |
 | `POST` | `/git/{project}/{repo}/git-receive-pack` | Smart HTTP git push data + post-receive hook; SHA values in ref-updates must be valid 40-char hex — non-hex SHAs rejected to prevent argument injection (M-8) |
@@ -443,6 +443,16 @@ Agents are created in dependency order (parents before children). Parent links a
 ```
 
 The server automatically: opens the MR, marks the task done, removes the git worktree, and marks the agent Idle.
+
+**Custom git ref namespaces (M13.6):** The server writes refs into reserved namespaces on each lifecycle event:
+
+| Event | Ref written | Purpose |
+|---|---|---|
+| `spawn` | `refs/agents/{agent-id}/head` | Points to the HEAD commit at spawn; survives branch force-pushes |
+| `spawn` | `refs/ralph/{task-id}/implement` | Marks the implement step of the Ralph loop for this task |
+| `complete` | `refs/agents/{agent-id}/snapshots/{n}` | Immutable snapshot of the branch tip at completion (n increments per call) |
+
+These refs survive agent restarts. Query them via standard git: `git ls-remote <clone-url> 'refs/agents/*'`.
 
 > `web/dist/` is committed so the server can serve the SPA without requiring `npm` at build
 > time. Agents and CI do not need Node installed to build or run `gyre-server`.


### PR DESCRIPTION
## Summary

Documents the custom git ref namespaces introduced by M13.6 (PR #121, now merged), which were missing from AGENTS.md.

Changes:
- **Endpoint table**: spawn and complete rows now note which refs are written
- **Spawn/Complete prose section**: new table showing all three ref namespaces with their purpose and a usage note

## What was missing

PR #121 added code in `spawn.rs` that writes refs on every agent lifecycle event:
- On `spawn`: `refs/agents/{id}/head` + `refs/ralph/{task-id}/implement`
- On `complete`: `refs/agents/{id}/snapshots/{n}`

Neither the endpoint table rows nor the prose section in AGENTS.md mentioned this behavior. Agents consuming the spawn/complete API had no way to know these refs existed.

## Test plan

- [x] `cargo fmt --check` passes (docs only, no Rust changes)
- [x] Content verified against `crates/gyre-server/src/api/spawn.rs` on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)