### PR TITLE
docs: PostgreSQL support, M12/M15 Done, test count 553/79

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ The git HTTP endpoints (`/git/...`) accept all four auth mechanisms so that `gyr
 | `GYRE_RATE_LIMIT` | `100` | Requests per second allowed per IP before 429 (M7.3) |
 | `GYRE_AUDIT_SIMULATE` | _(disabled)_ | Set to `true` to run the audit event simulator on startup (M7.1) |
 | `GYRE_REPOS_PATH` | `./repos/` | Directory for bare git repositories on disk. Created on startup if absent. (M10.3) |
-| `GYRE_DATABASE_URL` | _(unset — in-memory)_ | SQLite database URL, e.g. `sqlite://gyre.db`. When set, all port traits persist to SQLite with WAL mode; Diesel runs pending migrations automatically on startup. Unset = in-memory (default, stateless). (M10.1, M15.1) |
+| `GYRE_DATABASE_URL` | _(unset — in-memory)_ | Database URL. `sqlite://gyre.db` for SQLite or `postgres://user:pass@host/db` for PostgreSQL. When set, all port traits persist via Diesel ORM with auto-migrations. Unset = in-memory (default, stateless). (M10.1, M15.1, M15.2) |
 
 ### WebSocket Protocol (`gyre-common::WsMessage`)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ cargo build --release -p gyre-server -p gyre-cli
 
 # Run with persistent SQLite storage
 GYRE_DATABASE_URL=sqlite://gyre.db ./target/release/gyre-server
+
+# Run with PostgreSQL
+GYRE_DATABASE_URL=postgres://user:pass@localhost/gyre ./target/release/gyre-server
 ```
 
 Open **http://localhost:3000** — the dashboard loads immediately. Default auth token: `gyre-dev-token`.
@@ -56,7 +59,7 @@ All settings are environment variables. The server starts with safe defaults —
 |---|---|---|
 | `GYRE_PORT` | `3000` | HTTP/WS listen port |
 | `GYRE_AUTH_TOKEN` | `gyre-dev-token` | Bearer token for API auth |
-| `GYRE_DATABASE_URL` | _(unset — in-memory)_ | SQLite URL for persistence, e.g. `sqlite://gyre.db` |
+| `GYRE_DATABASE_URL` | _(unset — in-memory)_ | Database URL. Supports `sqlite://gyre.db` (SQLite) or `postgres://user:pass@host/db` (PostgreSQL). Diesel runs migrations automatically on startup. |
 | `GYRE_REPOS_PATH` | `./repos/` | Directory for bare git repositories |
 | `GYRE_BASE_URL` | `http://localhost:<port>` | Public URL used in clone URLs |
 | `RUST_LOG` | `info` | Log level (`debug`, `trace`, `warn`) |
@@ -75,7 +78,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 
 - **Rust** - server, CLI, agent runtime
 - **Svelte 5 + shadcn-svelte** - web UI (pre-built, no Node required to run)
-- **SQLite + Diesel ORM** - default storage; WAL mode, type-safe queries, auto-migrations, full persistence when `GYRE_DATABASE_URL` is set
+- **SQLite + PostgreSQL via Diesel ORM** - type-safe queries, auto-migrations on startup; `sqlite://` for default persistence, `postgres://` for production scale
 - **NixOS** - single definition builds server, Docker image, QEMU VM, LXC container
 - **WireGuard** - agent networking mesh
 
@@ -95,13 +98,13 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M9: Functional UI | Done | Seed data endpoint, CRUD modals (projects/repos/tasks), auth token integration, end-to-end user journeys |
 | M10: Persistent Storage | Done | SQLite persistence, real-time WebSocket events, git repo management |
 | M11: Agent Execution | Done | Real agent processes, TTY attach, agent logs, execution lifecycle |
-| M12: Quality Gates | In Progress | Merge queue gates, repo mirroring, diff viewer |
+| M12: Quality Gates | Done | Merge queue gates, repo mirroring, diff viewer with syntax highlighting |
 | M13: Forge Native | In Progress | Pre-accept validation, commit provenance, zero-latency feedback, cross-agent code awareness |
 | M14: Supply Chain Security | In Progress | Agent stack fingerprinting, push attestation, AIBOM generation |
-| M15: Diesel ORM | In Progress | Diesel ORM + migrations, full SQLite persistence, multi-tenancy (tenant_id scoping) |
+| M15: Diesel ORM | Done | Diesel ORM + migrations, SQLite + PostgreSQL adapters, full persistence, multi-tenancy (tenant_id scoping) |
 | M16: Security Hardening | Done | Constant-time token compare, SHA-256 API key hashing, path redaction, CORS hardening, audit guard, SSH host key enforcement |
 
-554 Rust + 31 frontend component tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+553 Rust + 79 frontend component tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications and [`AGENTS.md`](AGENTS.md) for the complete API and developer reference.
 


### PR DESCRIPTION
## Summary

Post-merge docs cleanup for PRs #120 (PostgreSQL adapter) and #127 (M12.3 syntax highlighting).

**README.md — 6 updates:**
- Quick Start: add `GYRE_DATABASE_URL=postgres://...` run example alongside SQLite
- Config table: `GYRE_DATABASE_URL` now documents `postgres://user:pass@host/db` support
- Tech Stack: `SQLite + Diesel ORM` → `SQLite + PostgreSQL via Diesel ORM`
- M12 status: **In Progress → Done** (diff viewer + syntax highlighting merged in #127)
- M15 status: **In Progress → Done** (PostgreSQL adapter merged in #120)
- Test count: `554 Rust + 31 frontend` → `553 Rust + 79 frontend` (verified from CI)

**AGENTS.md — 1 update:**
- `GYRE_DATABASE_URL` env var: add `postgres://` URL form, cite M15.2

## Test plan
- [x] `cargo fmt --check` passes (docs only)
- [x] All values verified against latest green CI run on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)