### PR TITLE
docs(agents): M13.7 — idempotent complete and token revocation behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `POST/GET` | `/api/v1/repos/{id}/worktrees` | Create / list worktrees |
 | `DELETE` | `/api/v1/repos/{id}/worktrees/{wt_id}` | Delete worktree |
 | `POST` | `/api/v1/agents/spawn` | Spawn agent: create record, generate token, provision worktree, assign task; writes `refs/agents/{id}/head` and `refs/ralph/{task-id}/implement` (M13.6) |
-| `POST` | `/api/v1/agents/{id}/complete` | Complete agent: open MR, mark task done, clean up worktree; writes `refs/agents/{id}/snapshots/{n}` snapshot ref (M13.6) |
+| `POST` | `/api/v1/agents/{id}/complete` | Complete agent: open MR, mark task done, clean up worktree; writes `refs/agents/{id}/snapshots/{n}` snapshot ref (M13.6); **idempotent** — returns 202 on double-complete; agent token revoked on success (M13.7) |
 | `GET` | `/git/{project}/{repo}/info/refs` | Smart HTTP git discovery (`?service=git-upload-pack` or `git-receive-pack`) |
 | `POST` | `/git/{project}/{repo}/git-upload-pack` | Smart HTTP git clone / fetch data |
 | `POST` | `/git/{project}/{repo}/git-receive-pack` | Smart HTTP git push data + post-receive hook; SHA values in ref-updates must be valid 40-char hex — non-hex SHAs rejected to prevent argument injection (M-8) |
@@ -443,6 +443,10 @@ Agents are created in dependency order (parents before children). Parent links a
 ```
 
 The server automatically: opens the MR, marks the task done, removes the git worktree, and marks the agent Idle.
+
+**Idempotent (M13.7):** Calling complete a second time returns **202 Accepted** rather than an error — safe to retry on network failure or agent restart.
+
+**Token revocation (M13.7):** The agent's bearer token is revoked in the database on successful completion. Any subsequent API call with the same token will be rejected with 401. Agents must not reuse a token after completing.
 
 **Custom git ref namespaces (M13.6):** The server writes refs into reserved namespaces on each lifecycle event:
 


### PR DESCRIPTION
## Summary

Documents the behavioral guarantees added by M13.7 (PR #123, now merged) that were missing from AGENTS.md.

## What was missing

The `POST /api/v1/agents/{id}/complete` endpoint table row and prose section had no mention of:

1. **Idempotent complete** — returns 202 Accepted on double-call; safe to retry on network error or agent restart
2. **Token revocation** — agent's bearer token is revoked on successful completion; re-use returns 401

Both are critical behavioral contracts for agents to know about.

## Changes

- Endpoint table row for `POST /api/v1/agents/{id}/complete`: added idempotent 202 + token revocation note
- Spawn/Complete prose section: two new paragraphs explicitly stating the guarantee and its implications

## Test plan
- [x] Pre-commit passes (docs only, no Rust changes)
- [x] Content verified against `crates/gyre-server/src/api/spawn.rs` on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)