### PR TITLE
fix(server): wire token revocation on agent complete (N-1)

### DIFF
--- a/crates/gyre-adapters/src/postgres/mod.rs
+++ b/crates/gyre-adapters/src/postgres/mod.rs
@@ -18,6 +18,7 @@ pub mod network_peer;
 pub mod project;
 pub mod repository;
 pub mod review;
+pub mod spawn_log;
 pub mod task;
 pub mod user;
 pub mod worktree;

--- a/crates/gyre-adapters/src/postgres/spawn_log.rs
+++ b/crates/gyre-adapters/src/postgres/spawn_log.rs
@@ -1,0 +1,150 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use diesel::prelude::*;
+use gyre_ports::{SpawnLogEntry, SpawnLogRepository};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::PgStorage;
+use crate::schema::{revoked_tokens, spawn_log};
+
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = spawn_log)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+struct SpawnLogRow {
+    #[allow(dead_code)]
+    id: String,
+    agent_id: String,
+    step: String,
+    status: String,
+    detail: Option<String>,
+    occurred_at: i64,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = spawn_log)]
+struct NewSpawnLogRow<'a> {
+    id: &'a str,
+    agent_id: &'a str,
+    step: &'a str,
+    status: &'a str,
+    detail: Option<&'a str>,
+    occurred_at: i64,
+}
+
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = revoked_tokens)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+struct RevokedTokenRow {
+    #[allow(dead_code)]
+    token_hash: String,
+    #[allow(dead_code)]
+    agent_id: String,
+    #[allow(dead_code)]
+    revoked_at: i64,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = revoked_tokens)]
+struct NewRevokedTokenRow<'a> {
+    token_hash: &'a str,
+    agent_id: &'a str,
+    revoked_at: i64,
+}
+
+#[async_trait]
+impl SpawnLogRepository for PgStorage {
+    async fn append_spawn_step(
+        &self,
+        agent_id: &str,
+        step: &str,
+        status: &str,
+        detail: Option<&str>,
+        occurred_at: u64,
+    ) -> Result<()> {
+        let pool = Arc::clone(&self.pool);
+        let id = Uuid::new_v4().to_string();
+        let agent_id = agent_id.to_string();
+        let step = step.to_string();
+        let status = status.to_string();
+        let detail = detail.map(|s| s.to_string());
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool.get().context("get db connection")?;
+            let row = NewSpawnLogRow {
+                id: &id,
+                agent_id: &agent_id,
+                step: &step,
+                status: &status,
+                detail: detail.as_deref(),
+                occurred_at: occurred_at as i64,
+            };
+            diesel::insert_into(spawn_log::table)
+                .values(&row)
+                .execute(&mut *conn)
+                .context("insert spawn_log entry")?;
+            Ok(())
+        })
+        .await?
+    }
+
+    async fn get_spawn_log(&self, agent_id: &str) -> Result<Vec<SpawnLogEntry>> {
+        let pool = Arc::clone(&self.pool);
+        let agent_id = agent_id.to_string();
+        tokio::task::spawn_blocking(move || -> Result<Vec<SpawnLogEntry>> {
+            let mut conn = pool.get().context("get db connection")?;
+            let rows = spawn_log::table
+                .filter(spawn_log::agent_id.eq(&agent_id))
+                .order(spawn_log::occurred_at.asc())
+                .load::<SpawnLogRow>(&mut *conn)
+                .context("load spawn_log")?;
+            Ok(rows
+                .into_iter()
+                .map(|r| SpawnLogEntry {
+                    agent_id: r.agent_id,
+                    step: r.step,
+                    status: r.status,
+                    detail: r.detail,
+                    occurred_at: r.occurred_at as u64,
+                })
+                .collect())
+        })
+        .await?
+    }
+
+    async fn revoke_token(&self, token_hash: &str, agent_id: &str, revoked_at: u64) -> Result<()> {
+        let pool = Arc::clone(&self.pool);
+        let token_hash = token_hash.to_string();
+        let agent_id = agent_id.to_string();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = pool.get().context("get db connection")?;
+            let row = NewRevokedTokenRow {
+                token_hash: &token_hash,
+                agent_id: &agent_id,
+                revoked_at: revoked_at as i64,
+            };
+            diesel::insert_into(revoked_tokens::table)
+                .values(&row)
+                .on_conflict(revoked_tokens::token_hash)
+                .do_nothing()
+                .execute(&mut *conn)
+                .context("insert revoked_token")?;
+            Ok(())
+        })
+        .await?
+    }
+
+    async fn is_token_revoked(&self, token_hash: &str) -> Result<bool> {
+        let pool = Arc::clone(&self.pool);
+        let token_hash = token_hash.to_string();
+        tokio::task::spawn_blocking(move || -> Result<bool> {
+            let mut conn = pool.get().context("get db connection")?;
+            let found = revoked_tokens::table
+                .find(&token_hash)
+                .first::<RevokedTokenRow>(&mut *conn)
+                .optional()
+                .context("check revoked_token")?;
+            Ok(found.is_some())
+        })
+        .await?
+    }
+}

--- a/crates/gyre-server/src/api/spawn.rs
+++ b/crates/gyre-server/src/api/spawn.rs
@@ -306,6 +306,9 @@ pub async fn complete_agent(
     let _ = agent.transition_status(AgentStatus::Idle);
     state.agents.update(&agent).await?;
 
+    // Revoke the agent's token — completed agents must not continue to authenticate (N-1).
+    state.agent_tokens.lock().await.remove(&id);
+
     // Write snapshot ref for this agent (best-effort)
     if let Ok(Some(repo)) = state.repos.find_by_id(&mr.repository_id).await {
         let snap_prefix = format!("refs/agents/{}/snapshots/", agent.id);
@@ -843,6 +846,61 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::CREATED);
         let mr_json = body_json(resp).await;
         assert_eq!(mr_json["author_agent_id"].as_str().unwrap(), &agent_id);
+    }
+
+    #[tokio::test]
+    async fn complete_revokes_agent_token() {
+        let app = app();
+        let (app, repo_id) = create_repo(app).await;
+        let (app, task_id) = create_task(app, "Revoke task").await;
+        let (app, spawn_json) = do_spawn(app, &repo_id, &task_id, "feat/revoke-test").await;
+        let agent_id = spawn_json["agent"]["id"].as_str().unwrap().to_string();
+        let agent_token = spawn_json["token"].as_str().unwrap().to_string();
+
+        // Complete the agent
+        let body = serde_json::json!({
+            "branch": "feat/revoke-test",
+            "title": "Done",
+            "target_branch": "main",
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/agents/{agent_id}/complete"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // The agent's token must now be rejected (401) — it was revoked on complete.
+        let spawn_body = serde_json::json!({
+            "name": "should-fail",
+            "repo_id": repo_id,
+            "task_id": task_id,
+            "branch": "feat/should-fail",
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/agents/spawn")
+                    .header("content-type", "application/json")
+                    .header("Authorization", format!("Bearer {agent_token}"))
+                    .body(Body::from(serde_json::to_vec(&spawn_body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "agent token must be invalid after complete"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Wire token revocation in `complete_agent`: after transitioning agent to Idle, remove the per-agent token from `state.agent_tokens` so completed agents can no longer authenticate
- Add `complete_revokes_agent_token` test: verifies the token returns 401 after `complete_agent` is called
- Add `SpawnLogRepository` impl for `PgStorage`: the `spawn_log` and `revoked_tokens` tables were in the schema but the postgres adapter was missing the implementation, causing a compile error when `GYRE_DATABASE_URL` pointed to postgres

## Test plan
- [x] `complete_revokes_agent_token` — new test verifies 401 after agent complete
- [x] All 332 gyre-server tests pass
- [x] All 139 gyre-adapters tests pass
- [x] E2E ralph loop test passes

Fixes CISO finding N-1: token revocation infrastructure was added (M13.7) but never wired in, so completed agent tokens stayed valid forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)