### PR TITLE
docs(agents): document POST /api/v1/release/prepare endpoint (M16)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `POST/GET` | `/api/v1/admin/compute-targets` | Create / list remote compute targets (Admin only) |
 | `GET/DELETE` | `/api/v1/admin/compute-targets/{id}` | Get / delete a compute target (Admin only) |
 | `POST` | `/api/v1/admin/seed` | Idempotent demo data seed: 2 projects, 3 repos, 4 agents, 6 tasks, 2 MRs, 1 queue entry, 5 activity events. Returns `{already_seeded:true}` on repeat. AdminOnly. (M9.1) |
+| `POST` | `/api/v1/release/prepare` | Admin: compute next semver version from conventional commits + generate changelog with agent/task attribution; optionally open a release MR. Request: `{repo_id, branch?, from?, create_mr?, mr_title?}`; `branch` and `from` validated against git argument injection — must not start with `-` or contain `..` (M16-A). Response: `{next_version, changelog, commit_count, mr?}` (M16) |
 | `POST/GET` | `/api/v1/audit/events` | Record / query eBPF audit events (`?agent_id=&event_type=&since=`) |
 | `GET` | `/api/v1/audit/stream` | SSE stream of live audit events |
 | `GET` | `/api/v1/audit/stats` | Audit event statistics and counts |


### PR DESCRIPTION
## Summary

Adds the missing AGENTS.md endpoint table entry for \`POST /api/v1/release/prepare\`, introduced in PR #135 but never documented.

Gap identified during review of PR #142 (refname validation on the same endpoint).

**Added row documents:**
- Request: \`{repo_id, branch?, from?, create_mr?, mr_title?}\`  
- Response: \`{next_version, changelog, commit_count, mr?}\`
- Security note: \`branch\` and \`from\` validated against git argument injection — must not start with \`-\` or contain \`...\` (CISO M16-A, fixed in PR #142)
- Admin-only endpoint, milestone M16

## Test plan

- [ ] Verify endpoint row is accurate against \`crates/gyre-server/src/api/release.rs\`
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)