### PR TITLE
fix(server): bind spec approval identity to authenticated caller (CISO M12.3-A)

### DIFF
--- a/crates/gyre-server/src/api/error.rs
+++ b/crates/gyre-server/src/api/error.rs
@@ -8,7 +8,14 @@ use serde_json::json;
 pub enum ApiError {
     NotFound(String),
     InvalidInput(String),
+    Forbidden(String),
     Internal(anyhow::Error),
+}
+
+impl ApiError {
+    pub fn forbidden(msg: impl Into<String>) -> Self {
+        ApiError::Forbidden(msg.into())
+    }
 }
 
 impl IntoResponse for ApiError {
@@ -16,6 +23,7 @@ impl IntoResponse for ApiError {
         let (status, message) = match self {
             ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             ApiError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, msg),
+            ApiError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
             ApiError::Internal(err) => {
                 tracing::error!("internal error: {err:#}");
                 (

--- a/crates/gyre-server/src/api/gates.rs
+++ b/crates/gyre-server/src/api/gates.rs
@@ -116,8 +116,6 @@ pub struct ApproveSpecRequest {
     pub path: String,
     /// Git blob SHA of the spec at approval time (must be 40-char hex).
     pub sha: String,
-    /// Approver identity, e.g. "user:jsell" or "agent:<uuid>".
-    pub approver_id: String,
     /// Optional Sigstore signature.
     pub signature: Option<String>,
 }
@@ -159,7 +157,6 @@ impl From<SpecApproval> for SpecApprovalResponse {
 pub struct RevokeSpecRequest {
     /// Approval ID to revoke.
     pub approval_id: String,
-    pub revoked_by: String,
     pub reason: String,
 }
 
@@ -280,9 +277,11 @@ pub async fn list_mr_gate_results(
 /// POST /api/v1/specs/approve — record an approval of a spec at a specific SHA.
 ///
 /// The SHA must be a 40-character hex string to prevent git argument injection.
-#[instrument(skip(state, req))]
+/// The approver identity is derived server-side from the authenticated caller.
+#[instrument(skip(state, req, auth))]
 pub async fn approve_spec(
     State(state): State<Arc<AppState>>,
+    auth: crate::auth::AuthenticatedAgent,
     Json(req): Json<ApproveSpecRequest>,
 ) -> Result<(StatusCode, Json<SpecApprovalResponse>), ApiError> {
     // Validate SHA is 40-char hex (security: prevents git argument injection).
@@ -296,14 +295,15 @@ pub async fn approve_spec(
             "spec path must not be empty".to_string(),
         ));
     }
-    if req.approver_id.is_empty() {
-        return Err(ApiError::InvalidInput(
-            "approver_id must not be empty".to_string(),
-        ));
-    }
+
+    // Derive approver_id server-side from authenticated caller — never trust client-supplied value.
+    let approver_id = auth
+        .user_id
+        .map(|id| format!("user:{id}"))
+        .unwrap_or_else(|| format!("agent:{}", auth.agent_id));
 
     let now = now_secs();
-    let mut approval = SpecApproval::new(new_id(), req.path, req.sha, req.approver_id, now);
+    let mut approval = SpecApproval::new(new_id(), req.path, req.sha, approver_id, now);
     approval.signature = req.signature;
 
     state
@@ -336,11 +336,22 @@ pub async fn list_spec_approvals(
 }
 
 /// POST /api/v1/specs/revoke — revoke an existing spec approval.
-#[instrument(skip(state, req))]
+///
+/// Only the original approver or an Admin may revoke an approval.
+#[instrument(skip(state, req, auth))]
 pub async fn revoke_spec_approval(
     State(state): State<Arc<AppState>>,
+    auth: crate::auth::AuthenticatedAgent,
     Json(req): Json<RevokeSpecRequest>,
 ) -> Result<Json<SpecApprovalResponse>, ApiError> {
+    // Derive caller identity server-side.
+    let caller_id = auth
+        .user_id
+        .as_ref()
+        .map(|id| format!("user:{id}"))
+        .unwrap_or_else(|| format!("agent:{}", auth.agent_id));
+    let is_admin = auth.roles.contains(&gyre_domain::UserRole::Admin);
+
     let mut approvals = state.spec_approvals.lock().await;
     let approval = approvals
         .get_mut(&req.approval_id)
@@ -352,8 +363,15 @@ pub async fn revoke_spec_approval(
         ));
     }
 
+    // Authorization: caller must be the original approver or an Admin.
+    if !is_admin && approval.approver_id != caller_id {
+        return Err(ApiError::forbidden(
+            "only the original approver or an Admin may revoke this approval",
+        ));
+    }
+
     approval.revoked_at = Some(now_secs());
-    approval.revoked_by = Some(req.revoked_by);
+    approval.revoked_by = Some(caller_id);
     approval.revocation_reason = Some(req.reason);
 
     Ok(Json(SpecApprovalResponse::from(approval.clone())))
@@ -612,10 +630,10 @@ mod tests {
     #[tokio::test]
     async fn approve_spec_and_list() {
         let app = app();
+        // Note: approver_id is NOT in the request body — it is derived server-side.
         let body = serde_json::json!({
             "path": "specs/system/agent-gates.md",
-            "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-            "approver_id": "user:jsell"
+            "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
         });
         let resp = app
             .clone()
@@ -634,6 +652,12 @@ mod tests {
         let json = body_json(resp).await;
         assert_eq!(json["spec_path"], "specs/system/agent-gates.md");
         assert_eq!(json["active"], true);
+        // Approver identity is derived from auth token, not the request body.
+        let approver_id = json["approver_id"].as_str().unwrap();
+        assert!(
+            approver_id.starts_with("agent:") || approver_id.starts_with("user:"),
+            "approver_id should be server-derived: {approver_id}"
+        );
 
         // list all
         let resp = app
@@ -651,13 +675,40 @@ mod tests {
         assert_eq!(json.as_array().unwrap().len(), 1);
     }
 
+    /// Client-supplied approver_id in body must be ignored (not trusted).
+    #[tokio::test]
+    async fn approve_spec_ignores_client_supplied_approver_id() {
+        let app = app();
+        // Include approver_id in body — server should ignore it and use auth identity.
+        let body = serde_json::json!({
+            "path": "specs/system/agent-gates.md",
+            "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "approver_id": "user:attacker"
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/specs/approve")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let json = body_json(resp).await;
+        // Must NOT be the attacker-supplied value.
+        assert_ne!(json["approver_id"], "user:attacker");
+    }
+
     #[tokio::test]
     async fn approve_spec_invalid_sha_rejected() {
         let app = app();
         let body = serde_json::json!({
             "path": "specs/system/agent-gates.md",
-            "sha": "not-a-sha",
-            "approver_id": "user:jsell"
+            "sha": "not-a-sha"
         });
         let resp = app
             .oneshot(
@@ -677,11 +728,10 @@ mod tests {
     #[tokio::test]
     async fn revoke_spec_approval() {
         let app = app();
-        // First approve
+        // First approve (same token = same caller)
         let body = serde_json::json!({
             "path": "specs/system/agent-gates.md",
-            "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-            "approver_id": "user:jsell"
+            "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
         });
         let resp = app
             .clone()
@@ -699,10 +749,10 @@ mod tests {
         let json = body_json(resp).await;
         let approval_id = json["id"].as_str().unwrap().to_string();
 
-        // Then revoke
+        // Then revoke with the same caller — should succeed.
+        // Note: revoked_by is NOT in the request body — it is derived server-side.
         let revoke_body = serde_json::json!({
             "approval_id": approval_id,
-            "revoked_by": "user:jsell",
             "reason": "spec was superseded"
         });
         let resp = app
@@ -721,5 +771,11 @@ mod tests {
         let json = body_json(resp).await;
         assert_eq!(json["active"], false);
         assert_eq!(json["revocation_reason"], "spec was superseded");
+        // revoked_by must be set to server-derived caller identity.
+        let revoked_by = json["revoked_by"].as_str().unwrap();
+        assert!(
+            revoked_by.starts_with("agent:") || revoked_by.starts_with("user:"),
+            "revoked_by should be server-derived: {revoked_by}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **CISO finding M12.3-A (MEDIUM):** spec approval endpoints were trusting client-supplied identity fields instead of binding to the authenticated caller
- `approve_spec`: `approver_id` is now derived server-side from the auth token; the field is removed from the request schema so clients cannot supply it
- `revoke_spec_approval`: `revoked_by` is now derived server-side; authorization check enforces that only the original approver or an Admin may revoke (returns 403 otherwise)
- Added `ApiError::Forbidden` variant (HTTP 403) to `error.rs`

## Changes

- `crates/gyre-server/src/api/error.rs`: add `Forbidden(String)` variant + `forbidden()` constructor
- `crates/gyre-server/src/api/gates.rs`:
  - Remove `approver_id` from `ApproveSpecRequest`
  - Remove `revoked_by` from `RevokeSpecRequest`
  - `approve_spec`: add `AuthenticatedAgent` extractor, derive `approver_id` as `user:<id>` or `agent:<id>` from auth context
  - `revoke_spec_approval`: add `AuthenticatedAgent` extractor, enforce owner-or-Admin check before revoking
  - New tests: `approve_spec_ignores_client_supplied_approver_id`, updated `revoke_spec_approval` to verify server-derived `revoked_by`

## Test plan

- [x] `cargo test -p gyre-server --lib api::gates` — 10/10 pass
- [x] Pre-commit hooks pass (cargo fmt, clippy, arch-lint, no-em-dash)
- [x] `approve_spec_ignores_client_supplied_approver_id` verifies attacker cannot set their own identity
- [x] `revoke_spec_approval` verifies `revoked_by` is server-derived

🤖 Generated with [Claude Code](https://claude.com/claude-code)