### PR TITLE
docs(agents): fix spec approval request schema — identity server-derived (CISO M12.3-A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,9 +116,9 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/repos/{id}/diff` | Diff between refs (`?from=<ref>&to=<ref>`) |
 | `POST/GET` | `/api/v1/repos/{id}/gates` | Create (**Admin required**) / list quality gates for a repo (`GateType`: TestCommand, LintCommand, RequiredApprovals, AgentReview, AgentValidation) (M12.1, M12.3) |
 | `DELETE` | `/api/v1/repos/{id}/gates/{gate_id}` | Delete a quality gate (M12.1) |
-| `POST` | `/api/v1/specs/approve` | Record spec approval: `{path, sha, approver_id}` — `sha` must be 40-char hex of the spec blob at approval time (M12.3) |
+| `POST` | `/api/v1/specs/approve` | Record spec approval: `{path, sha, signature?}` — `sha` must be 40-char hex; **approver identity derived server-side from auth token** (client must not supply `approver_id`) (CISO M12.3-A, M12.3) |
 | `GET` | `/api/v1/specs/approvals` | List spec approvals (`?path=<relative-path>` to filter by spec file) (M12.3) |
-| `POST` | `/api/v1/specs/revoke` | Revoke a spec approval: `{approval_id, revoked_by, reason}`; marks it inactive without deleting the audit record (M12.3) |
+| `POST` | `/api/v1/specs/revoke` | Revoke a spec approval: `{approval_id, reason}` — caller must be original approver or Admin (returns 403 otherwise); revoker identity derived server-side (client must not supply `revoked_by`) (CISO M12.3-A, M12.3) |
 | `GET/PUT` | `/api/v1/repos/{id}/push-gates` | Get / set active pre-accept push gates for a repo (built-in: ConventionalCommit, TaskRef, NoEmDash); **PUT requires Admin role** (M13.1) |
 | `GET` | `/api/v1/repos/{id}/blame?path={file}` | Per-line agent attribution — which agent last touched each line (M13.4) |
 | `GET` | `/api/v1/repos/{id}/hot-files?limit=20` | Files with the most concurrent active agents in the last 24h (M13.4) |


### PR DESCRIPTION
## Summary

Fixes stale AGENTS.md documentation introduced in PR #141 that documented the spec approval endpoints with client-supplied identity fields. PR #144 removes those fields from the API (CISO finding M12.3-A).

**Before (wrong after PR #144):**
```
POST /api/v1/specs/approve  →  {path, sha, approver_id}
POST /api/v1/specs/revoke   →  {approval_id, revoked_by, reason}
```

**After (correct):**
```
POST /api/v1/specs/approve  →  {path, sha, signature?}   (approver derived from auth token)
POST /api/v1/specs/revoke   →  {approval_id, reason}      (revoker derived from auth token; 403 if not owner/Admin)
```

## Changes

- `AGENTS.md`: update two endpoint rows to reflect the M12.3-A security fix

## Dependency

Should merge **after PR #144** (`fix/spec-approval-identity`) since that PR is what implements the API change this PR documents.

## Test plan

- [ ] No code changes — docs only
- [ ] Verify request schema against `crates/gyre-server/src/api/gates.rs` after PR #144 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)