### PR TITLE
docs: M17 milestone row in README + trusted foundry spec ref in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -688,6 +688,7 @@ Key specs to read before making changes:
 | M15 milestone deliverables | [specs/milestones/m15-diesel-migrations.md](specs/milestones/m15-diesel-migrations.md) |
 | Database & Migrations | [specs/development/database-migrations.md](specs/development/database-migrations.md) |
 | Forge-native advantages | [specs/system/forge-advantages.md](specs/system/forge-advantages.md) |
+| Trusted Foundry integration (future pattern) | [specs/system/trusted-foundry-integration.md](specs/system/trusted-foundry-integration.md) |
 | Agent experience + legibility | [specs/development/agent-experience.md](specs/development/agent-experience.md) |
 | CI, docs, release | [specs/development/ci-docs-release.md](specs/development/ci-docs-release.md) |
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M14: Supply Chain Security | In Progress | Agent stack fingerprinting, push attestation, AIBOM generation |
 | M15: Diesel ORM | Done | Diesel ORM + migrations, SQLite + PostgreSQL adapters, full persistence, multi-tenancy (tenant_id scoping) |
 | M16: Security Hardening | Done | Constant-time token compare, SHA-256 API key hashing, path redaction, CORS hardening, audit guard, SSH host key enforcement |
+| M17: Integration Testing | In Progress | REST API contract tests, git smart HTTP tests, merge queue system tests, auth matrix, Playwright E2E |
 
 606 Rust + 86 frontend component tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

Two small doc gaps identified during PR poll cycle:

**README.md:** Added M17 "In Progress" row to the milestone table. The M17 spec (comprehensive integration & E2E testing plan) merged in PR #146; implementation is underway (PR #148 adds M17.4 auth tests). The README was missing this milestone entirely.

**AGENTS.md:** Added reference to `specs/system/trusted-foundry-integration.md` in the Architecture Decisions table. This spec was added in PR #150 as a reference-only future pattern. Other system-level specs (forge-advantages, agent-gates, spec-lifecycle) are already listed there; the trusted foundry spec belongs in the same table so developers know it exists and shapes architecture decisions.

## Test plan
- [x] Pre-commit hooks pass
- [x] No new endpoints — docs-only change
- [x] Rebased on latest main (includes PR #150)

🤖 Generated with [Claude Code](https://claude.com/claude-code)