### PR TITLE
fix(server): enforce Developer role on MR dependency mutation endpoints (CISO P147-A)

### DIFF
--- a/crates/gyre-server/src/api/merge_deps.rs
+++ b/crates/gyre-server/src/api/merge_deps.rs
@@ -105,6 +105,7 @@ fn would_create_cycle(
 
 pub async fn set_dependencies(
     State(state): State<Arc<AppState>>,
+    _dev: crate::rbac::RequireDeveloper,
     Path(id): Path<String>,
     Json(req): Json<SetDependenciesRequest>,
 ) -> Result<(StatusCode, Json<DependenciesResponse>), ApiError> {
@@ -200,6 +201,7 @@ pub async fn get_dependencies(
 
 pub async fn remove_dependency(
     State(state): State<Arc<AppState>>,
+    _dev: crate::rbac::RequireDeveloper,
     Path((id, dep_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
     let mr_id = Id::new(&id);
@@ -225,6 +227,7 @@ pub async fn remove_dependency(
 
 pub async fn set_atomic_group(
     State(state): State<Arc<AppState>>,
+    _dev: crate::rbac::RequireDeveloper,
     Path(id): Path<String>,
     Json(req): Json<SetAtomicGroupRequest>,
 ) -> Result<Json<AtomicGroupResponse>, ApiError> {
@@ -311,6 +314,7 @@ mod tests {
                     .method("POST")
                     .uri("/api/v1/merge-requests")
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -337,6 +341,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr2_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -373,6 +378,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -396,6 +402,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr2_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -411,6 +418,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr1_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -436,6 +444,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr2_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -448,6 +457,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr3_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -462,6 +472,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr1_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -484,6 +495,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr2_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -499,6 +511,7 @@ mod tests {
                     .uri(format!(
                         "/api/v1/merge-requests/{mr2_id}/dependencies/{mr1_id}"
                     ))
+                    .header("authorization", "Bearer test-token")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -531,6 +544,7 @@ mod tests {
                     .uri(format!(
                         "/api/v1/merge-requests/{mr_id}/dependencies/no-such"
                     ))
+                    .header("authorization", "Bearer test-token")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -550,6 +564,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr_id}/atomic-group"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -587,6 +602,7 @@ mod tests {
                     .method("PUT")
                     .uri(format!("/api/v1/merge-requests/{mr_id}/dependencies"))
                     .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )


### PR DESCRIPTION
## Summary

- **CISO finding P147-A (MEDIUM):** MR dependency mutation endpoints had no role enforcement — any authenticated caller (including ReadOnly users) could mutate dependency graphs and atomic groups.
- Added `RequireDeveloper` extractor to `set_dependencies`, `remove_dependency`, and `set_atomic_group` handlers. ReadOnly callers now receive `403 {"error":"insufficient permissions"}`.
- Updated all existing unit tests to send `Authorization: Bearer test-token` on mutation requests.

## Affected endpoints

| Method | Path | Before | After |
|--------|------|--------|-------|
| `PUT` | `/api/v1/merge-requests/{id}/dependencies` | no role check | Developer+ required |
| `DELETE` | `/api/v1/merge-requests/{id}/dependencies/{dep_id}` | no role check | Developer+ required |
| `PUT` | `/api/v1/merge-requests/{id}/atomic-group` | no role check | Developer+ required |

Read-only endpoint (`GET /api/v1/merge-requests/{id}/dependencies`) unchanged — no role check needed for reads.

## Test plan

- [ ] All 9 `api::merge_deps` unit tests pass with auth headers
- [ ] `cargo test --all --lib` → 377 tests pass

Closes TASK-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)