### PR TITLE
fix(adapters): serialize env-sensitive jj_ops tests with Mutex

### DIFF
--- a/crates/gyre-adapters/src/jj_ops.rs
+++ b/crates/gyre-adapters/src/jj_ops.rs
@@ -133,6 +133,11 @@ impl JjOpsPort for JjOpsAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialize tests that mutate GYRE_JJ_PATH — env vars are process-global
+    // and parallel test threads cause intermittent failures without this lock.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn jj_available() -> bool {
         std::process::Command::new("jj")
@@ -145,15 +150,17 @@ mod tests {
     /// Unit test: JjOpsAdapter is constructible and uses GYRE_JJ_PATH.
     #[test]
     fn adapter_respects_env_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var("GYRE_JJ_PATH", "/custom/jj") };
         let adapter = JjOpsAdapter::new();
-        assert_eq!(adapter.jj_path, "/custom/jj");
         unsafe { std::env::remove_var("GYRE_JJ_PATH") };
+        assert_eq!(adapter.jj_path, "/custom/jj");
     }
 
     /// Unit test: default adapter uses "jj".
     #[test]
     fn adapter_default_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::remove_var("GYRE_JJ_PATH") };
         let adapter = JjOpsAdapter::default();
         assert_eq!(adapter.jj_path, "jj");


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure identified while monitoring PRs #154 and others.

**Root cause:** `adapter_respects_env_path` and `adapter_default_path` both mutate `GYRE_JJ_PATH`, a process-global environment variable. When `cargo test` runs them in parallel (the default), one test can observe the env var set by the other, causing a spurious assertion failure:

```
thread 'jj_ops::tests::adapter_default_path' panicked at:
assertion failed: left == right
  left:  "/custom/jj"   ← leaked from adapter_respects_env_path
  right: "jj"
```

This was observed on PRs #154 and confirmed not to be related to the PR's code changes. The test passed on re-run because parallel scheduling happened to differ.

**Fix:** Add `static ENV_LOCK: Mutex<()>` in the test module. Both env-sensitive tests acquire the lock before touching the env var, serializing them with respect to each other. No external dependencies added.

**Also:** Move the `assert_eq!` in `adapter_respects_env_path` to after `remove_var` so env cleanup happens even if the assertion panics.

## Test plan
- [x] `cargo test -p gyre-adapters jj_ops` passes: `2 passed; 0 failed; 6 ignored`
- [x] `cargo fmt` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)