### PR TITLE
fix(server): use HEAD:main push refspec for CI compat

### DIFF
--- a/crates/gyre-server/tests/e2e_ralph_loop.rs
+++ b/crates/gyre-server/tests/e2e_ralph_loop.rs
@@ -166,14 +166,16 @@ async fn full_ralph_loop_via_gyre() {
         git_local(&["config", "user.email", "ralph@gyre.local"], &work_dir);
         git_local(&["config", "user.name", "Ralph Worker"], &work_dir);
 
-        // After cloning an empty repo with git 2.28+, we are already on the unborn
-        // `main` branch — `git checkout -b main` would fail. Skip directly to commits.
+        // After cloning an empty repo the local branch name depends on the git
+        // client's `init.defaultBranch` setting (may be "master" or "main").
+        // Use `HEAD:main` to push to the remote `main` ref regardless of the
+        // local branch name.
         std::fs::write(work_dir.join("README.md"), "# gyre-e2e\n").unwrap();
         git_local(&["add", "."], &work_dir);
         git_local(&["commit", "-m", "chore: initial commit"], &work_dir);
 
-        // Push main to establish the base branch
-        let push_main = git_with_token(&["push", "origin", "main"], &work_dir, &agent_token_c);
+        // Push HEAD to establish the base branch as `main` on the remote.
+        let push_main = git_with_token(&["push", "origin", "HEAD:main"], &work_dir, &agent_token_c);
         assert!(
             push_main.status.success(),
             "git push main failed: {}",

--- a/crates/gyre-server/tests/git_integration.rs
+++ b/crates/gyre-server/tests/git_integration.rs
@@ -216,7 +216,7 @@ async fn push_valid_conventional_commit_accepted() {
         );
 
         // Push main.
-        git_with_token(&["push", "origin", "main"], &dir, &token_owned)
+        git_with_token(&["push", "origin", "HEAD:main"], &dir, &token_owned)
     })
     .await
     .unwrap();
@@ -274,7 +274,7 @@ async fn push_nonconventional_commit_rejected_by_gate() {
         std::fs::write(dir.join("init.md"), "init\n").unwrap();
         git_local(&["add", "."], &dir);
         git_local(&["commit", "-m", "chore: initial commit"], &dir);
-        let init_push = git_with_token(&["push", "origin", "main"], &dir, &token_owned);
+        let init_push = git_with_token(&["push", "origin", "HEAD:main"], &dir, &token_owned);
         let init_stderr = String::from_utf8_lossy(&init_push.stderr).to_string();
         assert!(
             init_push.status.success(),
@@ -358,7 +358,7 @@ async fn push_em_dash_commit_rejected_by_gate() {
         std::fs::write(dir.join("init.md"), "init\n").unwrap();
         git_local(&["add", "."], &dir);
         git_local(&["commit", "-m", "chore: initial commit"], &dir);
-        let init_push = git_with_token(&["push", "origin", "main"], &dir, &token_owned);
+        let init_push = git_with_token(&["push", "origin", "HEAD:main"], &dir, &token_owned);
         let init_stderr = String::from_utf8_lossy(&init_push.stderr).to_string();
         assert!(
             init_push.status.success(),
@@ -459,7 +459,7 @@ async fn push_records_agent_commit_provenance() {
         std::fs::write(dir.join("readme.md"), "# prov\n").unwrap();
         git_local(&["add", "."], &dir);
         git_local(&["commit", "-m", "chore: initial commit"], &dir);
-        let push_main = git_with_token(&["push", "origin", "main"], &dir, &agent_token_c);
+        let push_main = git_with_token(&["push", "origin", "HEAD:main"], &dir, &agent_token_c);
         let push_stderr = String::from_utf8_lossy(&push_main.stderr).to_string();
         assert!(
             push_main.status.success(),
@@ -581,7 +581,7 @@ async fn merge_queue_auto_merges_mr_and_commit_on_main() {
         std::fs::write(dir.join("readme.md"), "# mq\n").unwrap();
         git_local(&["add", "."], &dir);
         git_local(&["commit", "-m", "chore: initial commit"], &dir);
-        let push_main = git_with_token(&["push", "origin", "main"], &dir, &agent_token_c);
+        let push_main = git_with_token(&["push", "origin", "HEAD:main"], &dir, &agent_token_c);
         assert!(push_main.status.success(), "push main failed");
 
         // Feature branch.
@@ -846,7 +846,7 @@ async fn push_non_hex_sha_rejected_in_ref_update() {
         git_local(&["add", "."], &dir);
         git_local(&["commit", "-m", "chore: initial commit"], &dir);
 
-        let push = git_with_token(&["push", "origin", "main"], &dir, &token_owned);
+        let push = git_with_token(&["push", "origin", "HEAD:main"], &dir, &token_owned);
         let push_stderr = String::from_utf8_lossy(&push.stderr).to_string();
         assert!(push.status.success(), "initial push failed: {push_stderr}");
     })


### PR DESCRIPTION
## Summary

- CI runners with `init.defaultBranch=master` fail on `git push origin main` after cloning an empty repo — the local unborn branch is named `master`, not `main`
- Replace all 7 occurrences of `push origin main` with `push origin HEAD:main` in `e2e_ralph_loop.rs` and `git_integration.rs`
- Fixes CI regression introduced when M17.3 tests (PR #158) merged

## Root cause

When git clones an empty repo, the local branch name comes from `init.defaultBranch`. On GitHub Actions runners, this is `master` (not `main`). After `git commit`, the branch is `master`. Then `git push origin main` fails with "src refspec main does not match any". Using `HEAD:main` pushes the current local branch to the remote `main` ref regardless of local name.

## Test plan
- [x] All 7 `push origin main` occurrences replaced with `push origin HEAD:main`
- [x] `cargo fmt --all` passes
- CI should now pass consistently on any runner config

🤖 Generated with [Claude Code](https://claude.com/claude-code)