### PR TITLE
chore: add snapshots/ to .gitignore, remove committed test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@
 web/node_modules/
 repos/
 crates/gyre-server/repos/
+
+# Runtime snapshots (created by POST /api/v1/admin/snapshot)
+snapshots/
+crates/gyre-server/snapshots/

--- a/crates/gyre-server/snapshots/1774046900.json
+++ b/crates/gyre-server/snapshots/1774046900.json
@@ -1,6 +1,0 @@
-{
-  "created_at": 1774046900,
-  "projects": [],
-  "agents": [],
-  "tasks": []
-}

--- a/crates/gyre-server/snapshots/1774046918.json
+++ b/crates/gyre-server/snapshots/1774046918.json
@@ -1,6 +1,0 @@
-{
-  "created_at": 1774046918,
-  "projects": [],
-  "agents": [],
-  "tasks": []
-}

--- a/crates/gyre-server/snapshots/1774047019.json
+++ b/crates/gyre-server/snapshots/1774047019.json
@@ -1,6 +1,0 @@
-{
-  "created_at": 1774047019,
-  "projects": [],
-  "agents": [],
-  "tasks": []
-}


### PR DESCRIPTION
## Summary

- 3 runtime DB snapshot files (`crates/gyre-server/snapshots/*.json`) were accidentally committed in PR #158's test run
- These are created by `POST /api/v1/admin/snapshot` when the server runs; they're runtime artifacts, not source files
- Added `snapshots/` and `crates/gyre-server/snapshots/` to `.gitignore`
- Removed the 3 JSON files from git tracking

## Root cause

The `GYRE_SNAPSHOT_PATH` env var defaults to `./snapshots/`. Integration tests start the server in the repo directory, so snapshots were created inside `crates/gyre-server/snapshots/` and committed unintentionally.

## Test plan
- [x] Snapshot JSON files removed from index
- [x] `.gitignore` updated to prevent recurrence
- [x] CI should be unaffected (test-only cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)