### PR TITLE
docs: update Rust test count 710 → 722 (M17.3 git integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M16: Security Hardening | Done | Constant-time token compare, SHA-256 API key hashing, path redaction, CORS hardening, audit guard, SSH host key enforcement |
 | M17: Integration Testing | In Progress | REST API contract tests, git smart HTTP tests, merge queue system tests, auth matrix, Playwright E2E |
 
-710 Rust + 92 vitest component + 20 Playwright E2E tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
+722 Rust + 92 vitest component + 20 Playwright E2E tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 
 See [`specs/`](specs/index.md) for full specifications and [`AGENTS.md`](AGENTS.md) for the complete API and developer reference.
 


### PR DESCRIPTION
## Summary

PR #158 added 12 new git integration tests in `git_integration.rs` (M17.3), bringing the total Rust test count from 710 to 722. Verified from CI run 23366562673 on main.

## New tests added by PR #158

- `clone_via_smart_http`
- `push_valid_conventional_commit_accepted`
- `push_nonconventional_commit_rejected_by_gate`
- `push_em_dash_commit_rejected_by_gate`
- `push_records_agent_commit_provenance`
- `merge_queue_auto_merges_mr_and_commit_on_main`
- `merge_queue_blocks_mr_with_pending_dependency`
- `push_non_hex_sha_rejected_in_ref_update`
- `clone_without_auth_rejected`
- `info_refs_content_type_matches_service`
- `push_to_mirror_repo_rejected`
- `queue_graph_reflects_enqueued_mrs_and_deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)