### PR TITLE
feat(server): wire spec approval enforcement at merge time

### DIFF
--- a/crates/gyre-server/src/api/mod.rs
+++ b/crates/gyre-server/src/api/mod.rs
@@ -25,6 +25,7 @@ pub mod push_gates;
 pub mod release;
 pub mod repos;
 pub mod spawn;
+pub mod spec_policy;
 pub mod speculative;
 pub mod stack_attest;
 pub mod tasks;
@@ -117,6 +118,11 @@ pub fn api_router() -> Router<Arc<AppState>> {
         .route(
             "/api/v1/repos/:id/stack-policy",
             get(stack_attest::get_stack_policy).put(stack_attest::set_stack_policy),
+        )
+        // Spec enforcement policy (M12.3)
+        .route(
+            "/api/v1/repos/:id/spec-policy",
+            get(spec_policy::get_spec_policy).put(spec_policy::set_spec_policy),
         )
         // Cross-agent code awareness (M13.4)
         .route("/api/v1/repos/:id/blame", get(code_awareness::get_blame))

--- a/crates/gyre-server/src/api/spec_policy.rs
+++ b/crates/gyre-server/src/api/spec_policy.rs
@@ -1,0 +1,220 @@
+//! Per-repo spec enforcement policy.
+//!
+//! GET  /api/v1/repos/:id/spec-policy  — get current policy
+//! PUT  /api/v1/repos/:id/spec-policy  — set policy (AdminOnly)
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use gyre_common::Id;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::AppState;
+
+use super::error::ApiError;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Per-repo spec enforcement policy.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct SpecPolicy {
+    /// If true, MRs without a `spec_ref` field are blocked from merging.
+    pub require_spec_ref: bool,
+    /// If true, MRs whose `spec_ref` has no active approval in the ledger are blocked.
+    /// Implies `require_spec_ref` — both are checked when this is true.
+    pub require_approved_spec: bool,
+}
+
+#[derive(Serialize)]
+pub struct SpecPolicyResponse {
+    pub repo_id: String,
+    pub require_spec_ref: bool,
+    pub require_approved_spec: bool,
+}
+
+impl SpecPolicyResponse {
+    fn from_policy(repo_id: String, policy: &SpecPolicy) -> Self {
+        SpecPolicyResponse {
+            repo_id,
+            require_spec_ref: policy.require_spec_ref,
+            require_approved_spec: policy.require_approved_spec,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// GET /api/v1/repos/:id/spec-policy — get current spec enforcement policy.
+pub async fn get_spec_policy(
+    State(state): State<Arc<AppState>>,
+    Path(repo_id): Path<String>,
+) -> Result<Json<SpecPolicyResponse>, ApiError> {
+    state
+        .repos
+        .find_by_id(&Id::new(&repo_id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("repo {repo_id} not found")))?;
+
+    let policy = state
+        .spec_policies
+        .lock()
+        .await
+        .get(&repo_id)
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(Json(SpecPolicyResponse::from_policy(repo_id, &policy)))
+}
+
+/// PUT /api/v1/repos/:id/spec-policy — set spec enforcement policy (AdminOnly).
+pub async fn set_spec_policy(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminOnly,
+    Path(repo_id): Path<String>,
+    Json(req): Json<SpecPolicy>,
+) -> Result<(StatusCode, Json<SpecPolicyResponse>), ApiError> {
+    state
+        .repos
+        .find_by_id(&Id::new(&repo_id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("repo {repo_id} not found")))?;
+
+    state
+        .spec_policies
+        .lock()
+        .await
+        .insert(repo_id.clone(), req.clone());
+
+    Ok((
+        StatusCode::OK,
+        Json(SpecPolicyResponse::from_policy(repo_id, &req)),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::mem::test_state;
+    use axum::{body::Body, Router};
+    use gyre_domain::Repository;
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    fn app_with_repo() -> (Router, std::sync::Arc<crate::AppState>) {
+        let state = test_state();
+        let repo = Repository::new(
+            gyre_common::Id::new("repo-1"),
+            gyre_common::Id::new("proj-1"),
+            "test-repo",
+            "/tmp/test-repo",
+            0,
+        );
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(state.repos.create(&repo))
+                .unwrap();
+        });
+        let app = crate::api::api_router().with_state(state.clone());
+        (app, state)
+    }
+
+    async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_spec_policy_defaults_to_false() {
+        let (app, _state) = app_with_repo();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/repos/repo-1/spec-policy")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(!json["require_spec_ref"].as_bool().unwrap());
+        assert!(!json["require_approved_spec"].as_bool().unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_then_get_spec_policy() {
+        let (app, _state) = app_with_repo();
+        let body = serde_json::json!({
+            "require_spec_ref": true,
+            "require_approved_spec": false
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/repos/repo-1/spec-policy")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(json["require_spec_ref"].as_bool().unwrap());
+        assert!(!json["require_approved_spec"].as_bool().unwrap());
+
+        // GET returns same values.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/repos/repo-1/spec-policy")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(json["require_spec_ref"].as_bool().unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_spec_policy_unknown_repo_returns_404() {
+        let state = test_state();
+        let app = crate::api::api_router().with_state(state);
+        let body = serde_json::json!({
+            "require_spec_ref": true,
+            "require_approved_spec": true
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/repos/no-such/spec-policy")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -163,6 +163,8 @@ pub struct AppState {
     pub db_storage: Option<Arc<gyre_adapters::SqliteStorage>>,
     /// Spec approval ledger: approval_id -> SpecApproval (agent-gates).
     pub spec_approvals: Arc<Mutex<HashMap<String, gyre_domain::SpecApproval>>>,
+    /// Per-repo spec enforcement policies: repo_id -> SpecPolicy (M12.3).
+    pub spec_policies: Arc<Mutex<HashMap<String, api::spec_policy::SpecPolicy>>>,
 }
 
 /// Global authentication middleware for all `/api/v1/` routes.
@@ -429,6 +431,7 @@ pub fn build_state(
         repo_stack_policies: Arc::new(Mutex::new(HashMap::new())),
         db_storage,
         spec_approvals: Arc::new(Mutex::new(HashMap::new())),
+        spec_policies: Arc::new(Mutex::new(HashMap::new())),
     })
 }
 

--- a/crates/gyre-server/src/mem.rs
+++ b/crates/gyre-server/src/mem.rs
@@ -1127,5 +1127,6 @@ pub fn test_state() -> Arc<crate::AppState> {
         repo_stack_policies: Arc::new(Mutex::new(HashMap::new())),
         db_storage: None,
         spec_approvals: Arc::new(Mutex::new(HashMap::new())),
+        spec_policies: Arc::new(Mutex::new(HashMap::new())),
     })
 }

--- a/crates/gyre-server/src/merge_processor.rs
+++ b/crates/gyre-server/src/merge_processor.rs
@@ -151,6 +151,45 @@ async fn process_next(state: &AppState) -> anyhow::Result<()> {
         }
     }
 
+    // Check spec enforcement policy before merging.
+    {
+        let policy = state
+            .spec_policies
+            .lock()
+            .await
+            .get(&repo.id.to_string())
+            .cloned()
+            .unwrap_or_default();
+
+        if policy.require_spec_ref || policy.require_approved_spec {
+            if mr.spec_ref.is_none() {
+                let reason = "spec policy requires a spec_ref but MR has none".to_string();
+                warn!(entry_id = %entry.id, %reason, "spec policy blocked merge");
+                state
+                    .merge_queue
+                    .update_status(&entry.id, MergeQueueEntryStatus::Failed, Some(reason))
+                    .await?;
+                return Ok(());
+            }
+
+            if policy.require_approved_spec {
+                let spec_ref = mr.spec_ref.as_deref().unwrap();
+                if let Err(reason) = crate::api::gates::verify_spec_ref(state, spec_ref).await {
+                    warn!(entry_id = %entry.id, %reason, "spec approval check blocked merge");
+                    state
+                        .merge_queue
+                        .update_status(
+                            &entry.id,
+                            MergeQueueEntryStatus::Failed,
+                            Some(format!("spec approval required: {reason}")),
+                        )
+                        .await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
     // Check quality gates before merging.
     match crate::gate_executor::check_gates_for_mr(state, &mr.id).await {
         Ok(true) => {} // all passed or no gates

--- a/crates/gyre-server/src/middleware.rs
+++ b/crates/gyre-server/src/middleware.rs
@@ -153,6 +153,7 @@ mod tests {
             repo_stack_policies: base.repo_stack_policies.clone(),
             db_storage: base.db_storage.clone(),
             spec_approvals: base.spec_approvals.clone(),
+            spec_policies: base.spec_policies.clone(),
         });
         crate::build_router(state)
     }


### PR DESCRIPTION
## Summary
- Adds per-repo `SpecPolicy` with `require_spec_ref` and `require_approved_spec` flags stored in `AppState`
- Merge processor checks policy before each merge: missing `spec_ref` or un-approved spec fails the queue entry
- New endpoints: `GET/PUT /api/v1/repos/:id/spec-policy` (PUT requires Admin role)
- Defaults to both flags `false` for full backwards compatibility

## Test plan
- [x] 3 new unit tests in `api::spec_policy::tests` (GET defaults, SET+GET roundtrip, 404 on unknown repo)
- [x] 380 existing unit tests still pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

Closes TASK-116

🤖 Generated with [Claude Code](https://claude.com/claude-code)