### PR TITLE
feat(server): P4+P5 MR dependency auto-detection from branch lineage + failure handling

### DIFF
--- a/crates/gyre-server/src/api/merge_requests.rs
+++ b/crates/gyre-server/src/api/merge_requests.rs
@@ -7,7 +7,7 @@ use gyre_common::Id;
 use gyre_domain::{AnalyticsEvent, MergeRequest, MrStatus, Review, ReviewComment, ReviewDecision};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::instrument;
+use tracing::{info, instrument};
 
 use crate::domain_events::DomainEvent;
 use crate::AppState;
@@ -255,7 +255,7 @@ pub async fn create_mr(
     mr.author_agent_id = req.author_agent_id.map(Id::new);
     mr.spec_ref = req.spec_ref;
 
-    // Compute diff stats and conflict detection if the repository has a path
+    // Compute diff stats, conflict detection, and auto-detect branch lineage deps.
     if let Ok(Some(repo)) = state.repos.find_by_id(&repo_id).await {
         if let Ok(diff) = state
             .git_ops
@@ -275,6 +275,18 @@ pub async fn create_mr(
         {
             mr.has_conflicts = Some(!can_merge);
         }
+        // Auto-detect branch lineage dependencies (P4).
+        let lineage_deps = detect_lineage_deps(
+            &state,
+            &repo_id,
+            &repo.path,
+            &req.source_branch,
+            &req.target_branch,
+        )
+        .await;
+        if !lineage_deps.is_empty() {
+            mr.depends_on = lineage_deps;
+        }
     }
 
     state.merge_requests.create(&mr).await?;
@@ -282,6 +294,103 @@ pub async fn create_mr(
         id: mr.id.to_string(),
     });
     Ok((StatusCode::CREATED, Json(MrResponse::from(mr))))
+}
+
+/// Auto-detect MR dependencies based on git branch lineage (P4).
+///
+/// For each open MR in the same repo targeting the same target branch, checks
+/// whether `source_branch` is a descendant of that MR's source branch by
+/// comparing the merge-base to the candidate branch tip. If merge-base == tip,
+/// the new branch was created from the candidate branch and should depend on it.
+async fn detect_lineage_deps(
+    state: &Arc<AppState>,
+    repo_id: &Id,
+    repo_path: &str,
+    source_branch: &str,
+    target_branch: &str,
+) -> Vec<Id> {
+    let all_mrs = match state.merge_requests.list_by_repo(repo_id).await {
+        Ok(mrs) => mrs,
+        Err(_) => return vec![],
+    };
+
+    let candidates: Vec<_> = all_mrs
+        .into_iter()
+        .filter(|m| {
+            m.target_branch == target_branch
+                && m.source_branch != source_branch
+                && m.status == MrStatus::Open
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return vec![];
+    }
+
+    let git_bin = std::env::var("GYRE_GIT_PATH").unwrap_or_else(|_| "git".to_string());
+    let mut deps = Vec::new();
+
+    // Validate a branch name is safe to pass to git (no flag injection).
+    let is_safe_branch = |b: &str| !b.starts_with('-') && !b.contains("..");
+
+    if !is_safe_branch(source_branch) {
+        return vec![];
+    }
+
+    for candidate in candidates {
+        let cand_branch = &candidate.source_branch;
+        if !is_safe_branch(cand_branch) {
+            continue;
+        }
+
+        // Get the tip SHA of the candidate branch.
+        let tip_out = tokio::process::Command::new(&git_bin)
+            .arg("-C")
+            .arg(repo_path)
+            .arg("rev-parse")
+            .arg(format!("refs/heads/{cand_branch}"))
+            .output()
+            .await
+            .ok();
+
+        let cand_tip = match tip_out.as_ref().filter(|o| o.status.success()) {
+            Some(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+            None => continue,
+        };
+
+        if cand_tip.is_empty() || !cand_tip.chars().all(|c| c.is_ascii_hexdigit()) {
+            continue;
+        }
+
+        // Get the merge-base of the candidate branch and the new source branch.
+        let mb_out = tokio::process::Command::new(&git_bin)
+            .arg("-C")
+            .arg(repo_path)
+            .arg("merge-base")
+            .arg(format!("refs/heads/{cand_branch}"))
+            .arg(format!("refs/heads/{source_branch}"))
+            .output()
+            .await
+            .ok();
+
+        let merge_base = match mb_out.as_ref().filter(|o| o.status.success()) {
+            Some(o) => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+            None => continue,
+        };
+
+        // If merge-base == cand tip, source_branch is a descendant of cand branch.
+        if !merge_base.is_empty() && merge_base == cand_tip {
+            info!(
+                source = source_branch,
+                parent_branch = %cand_branch,
+                mr_id = %candidate.id,
+                "auto-detected branch lineage dependency"
+            );
+            deps.push(candidate.id);
+        }
+    }
+
+    deps
 }
 
 pub async fn list_mrs(

--- a/crates/gyre-server/src/merge_processor.rs
+++ b/crates/gyre-server/src/merge_processor.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use gyre_common::Id;
-use gyre_domain::{AnalyticsEvent, MergeQueueEntryStatus, MergeResult, MrStatus};
+use gyre_domain::{
+    AnalyticsEvent, GateStatus, MergeQueueEntry, MergeQueueEntryStatus, MergeRequest, MergeResult,
+    MrStatus, TaskPriority,
+};
 use uuid::Uuid;
 
 use crate::AppState;
@@ -67,6 +70,89 @@ async fn atomic_group_ready(state: &AppState, group: &str, mr_id: &Id) -> anyhow
     Ok(true)
 }
 
+/// Check dependencies for health issues and handle them (P5):
+///
+/// - Closed deps: creates a remediation task and fails the queue entry.
+/// - Deps with 3+ gate failures: logs an escalation warning.
+///
+/// Returns `true` if a blocking issue was found (caller should skip further processing).
+async fn handle_dep_health_issues(
+    state: &AppState,
+    entry: &MergeQueueEntry,
+    mr: &MergeRequest,
+) -> anyhow::Result<bool> {
+    for dep_id in &mr.depends_on {
+        let dep = match state.merge_requests.find_by_id(dep_id).await? {
+            Some(d) => d,
+            None => continue,
+        };
+
+        // Case 1: Dependency MR was closed before merging.
+        if dep.status == MrStatus::Closed {
+            warn!(
+                mr_id = %mr.id,
+                dep_id = %dep_id,
+                "dependency MR was closed; failing queue entry and creating reassessment task"
+            );
+
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let task_id = Id::new(Uuid::new_v4().to_string());
+            let mut task = gyre_domain::Task::new(
+                task_id,
+                format!("Dependency MR-{dep_id} was closed, reassess MR-{}", mr.id),
+                now,
+            );
+            task.priority = TaskPriority::High;
+            task.labels = vec!["dep-failure".to_string(), "auto-created".to_string()];
+            task.description = Some(format!(
+                "Dependency merge request {dep_id} was closed before merging. \
+                 Review whether MR {} can still proceed or needs to be updated.",
+                mr.id
+            ));
+            if let Err(e) = state.tasks.create(&task).await {
+                warn!(mr_id = %mr.id, "failed to create dep-failure task: {e}");
+            }
+
+            state
+                .merge_queue
+                .update_status(
+                    &entry.id,
+                    MergeQueueEntryStatus::Failed,
+                    Some(format!("dependency MR-{dep_id} was closed")),
+                )
+                .await?;
+
+            return Ok(true);
+        }
+
+        // Case 2: Dependency has 3+ gate failures — log escalation.
+        let gate_fail_count = {
+            let results = state.gate_results.lock().await;
+            results
+                .values()
+                .filter(|r| {
+                    r.mr_id.as_str() == dep_id.as_str() && matches!(r.status, GateStatus::Failed)
+                })
+                .count()
+        };
+
+        if gate_fail_count >= 3 {
+            warn!(
+                mr_id = %mr.id,
+                dep_id = %dep_id,
+                gate_fail_count,
+                "dependency MR has {} gate failures; escalating — manual intervention may be needed",
+                gate_fail_count,
+            );
+        }
+    }
+
+    Ok(false)
+}
+
 async fn process_next(state: &AppState) -> anyhow::Result<()> {
     // Get all queued entries and find the first one whose dependencies are all merged.
     let all_queued = state.merge_queue.list_queue().await?;
@@ -115,6 +201,11 @@ async fn process_next(state: &AppState) -> anyhow::Result<()> {
             return Ok(());
         }
     };
+
+    // P5: Check dependency health (closed deps, gate failure escalation).
+    if handle_dep_health_issues(state, &entry, &mr).await? {
+        return Ok(());
+    }
 
     // Look up the repository
     let repo = match state.repos.find_by_id(&mr.repository_id).await? {


### PR DESCRIPTION
## Summary

- **P4 — Branch lineage auto-detection**: When creating an MR, the server now checks if the source branch is a descendant of any other open MR's source branch (via `git merge-base`). If so, the parent MR is auto-added to `depends_on`. Branch names are validated to prevent git argument injection.
- **P5 — Dependency failure handling**: The merge processor now calls `handle_dep_health_issues` before processing each queued entry:
  - If a dependency MR is `Closed`, creates a High-priority task `"Dependency MR-{id} was closed, reassess MR-{dependent_id}"` and marks the queue entry `Failed`.
  - If a dependency has 3+ gate failures, emits a `warn!()` escalation log.

## Files changed
- `crates/gyre-server/src/api/merge_requests.rs` — `detect_lineage_deps()` + wired into `create_mr`
- `crates/gyre-server/src/merge_processor.rs` — `handle_dep_health_issues()` + wired into `process_next`

## Test plan
- [x] `cargo build -p gyre-server` — clean build
- [x] `cargo test -p gyre-server --lib` — 377 tests pass, 0 failures
- [x] `cargo clippy` — no warnings

Closes TASK-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)