### PR TITLE
fix(test): checkout main after second clone to fix non-fast-forward push

### DIFF
--- a/crates/gyre-server/tests/git_integration.rs
+++ b/crates/gyre-server/tests/git_integration.rs
@@ -1252,7 +1252,16 @@ async fn spec_approval_auto_invalidated_on_spec_change() {
         git_local(&["config", "user.email", "spec-inv@gyre.local"], &dir);
         git_local(&["config", "user.name", "Spec Inv Agent"], &dir);
 
-        // Ensure directory exists (clone of empty repo may not have it).
+        // CI runners default init.defaultBranch=master; remote HEAD may still
+        // point to master (unborn) even though main was pushed in step 1.
+        // Checkout main explicitly so we build on the existing commit history
+        // and avoid a non-fast-forward push rejection.
+        let _ = std::process::Command::new("git")
+            .args(["checkout", "main"])
+            .current_dir(&dir)
+            .status();
+
+        // Ensure directory exists (in case checkout missed it somehow).
         std::fs::create_dir_all(dir.join("specs/system")).unwrap();
         // Modify the spec file.
         std::fs::write(


### PR DESCRIPTION
## Summary

Fixes remaining main CI regression after #174. The `spec_approval_auto_invalidated_on_spec_change` test still fails on GitHub Actions CI with "non-fast-forward rejected."

**Root cause:**

GitHub Actions runners have `init.defaultBranch=master`. The server's bare repo also initializes with `HEAD -> master`. Step 1 pushes commits to `HEAD:main`, creating `main` on the remote — but remote `HEAD` still points to the unborn `master`. When step 3 clones the repo, git checks out `master` (empty working tree, no history). The subsequent commit becomes a **root commit on master** with no parent from `main`'s history, so `git push origin HEAD:main` fails: "rejected (non-fast-forward)."

PR #174 only added `create_dir_all` (fixes the `NotFound` panic from an empty working tree) but did not add the `git checkout main` needed to get on the right branch with existing history.

**Fix:** Add `git checkout main` after the second clone — same pattern already in use in `e2e_ralph_loop.rs` and documented in project CI pitfalls.

## Test plan

- [ ] CI Build passes on this PR
- [ ] `spec_approval_auto_invalidated_on_spec_change` passes on CI runner (not just locally)
- [ ] Main CI returns green after merge
- [ ] PR #167 (accessibility) Build CI unblocked after rebase on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)