### PR TITLE
fix(server): dynamically include server port in CORS default origins

### DIFF
--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -284,11 +284,30 @@ pub fn build_router(state: Arc<AppState>) -> Router {
 }
 
 /// Build a CORS layer from `GYRE_CORS_ORIGINS` env var.
+///
+/// When `GYRE_CORS_ORIGINS` is not set, the default list includes the server's
+/// own port (from `GYRE_PORT`) so that the dashboard works on non-default ports
+/// without requiring explicit CORS configuration.
 fn build_cors_layer() -> tower_http::cors::CorsLayer {
     use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
 
     let origins_str = std::env::var("GYRE_CORS_ORIGINS").unwrap_or_else(|_| {
-        "http://localhost:2222,http://localhost:3000,http://localhost:5173".to_string()
+        // Always include the server's own port so preflight requests succeed
+        // when running on a non-default port (e.g. GYRE_PORT=2223).
+        let server_port: u16 = std::env::var("GYRE_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3000);
+        let server_origin = format!("http://localhost:{server_port}");
+        let mut defaults = vec![
+            "http://localhost:2222".to_string(),
+            "http://localhost:3000".to_string(),
+            "http://localhost:5173".to_string(),
+        ];
+        if !defaults.contains(&server_origin) {
+            defaults.push(server_origin);
+        }
+        defaults.join(",")
     });
 
     if origins_str == "*" {

--- a/crates/gyre-server/tests/api_integration.rs
+++ b/crates/gyre-server/tests/api_integration.rs
@@ -1627,3 +1627,58 @@ async fn api_key_creation() {
     assert_ne!(resp.status(), 404_u16, "endpoint should exist");
     assert_ne!(resp.status(), 401_u16, "should be authenticated");
 }
+
+// ── CORS tests ────────────────────────────────────────────────────────────────
+
+/// Verify that the CORS preflight response includes the server's own port in
+/// Access-Control-Allow-Origin when GYRE_PORT matches the listening port.
+///
+/// Regression test for: boss 401 bug on port 2223 — CORS default only listed
+/// 2222/3000/5173, so preflight for GET+Authorization from port 2223 failed.
+#[tokio::test]
+async fn cors_includes_server_port() {
+    // Spin up a server on a random port, set GYRE_PORT so the CORS layer picks it up.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    // SAFETY: tests are single-threaded per tokio runtime; we set the env var
+    // before building state so the CORS layer reads the correct port.
+    // This env var is only consumed at startup, so parallel tests are not affected.
+    unsafe { std::env::set_var("GYRE_PORT", port.to_string()) };
+
+    let base_url = format!("http://127.0.0.1:{port}");
+    let state = build_state(TOKEN, &base_url, None);
+    let app = build_router(Arc::clone(&state));
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    // Clean up env var immediately after server startup so parallel tests are not affected.
+    unsafe { std::env::remove_var("GYRE_PORT") };
+
+    let client = reqwest::Client::new();
+    let origin = format!("http://localhost:{port}");
+
+    // Send a CORS preflight OPTIONS request simulating a browser requesting
+    // a credentialed GET (Authorization header triggers preflight).
+    let resp = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{base_url}/api/v1/version"),
+        )
+        .header("Origin", &origin)
+        .header("Access-Control-Request-Method", "GET")
+        .header("Access-Control-Request-Headers", "authorization")
+        .send()
+        .await
+        .unwrap();
+
+    let allow_origin = resp
+        .headers()
+        .get("access-control-allow-origin")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    assert_eq!(
+        allow_origin, origin,
+        "CORS allow-origin should include the server's own port (http://localhost:{port})"
+    );
+}


### PR DESCRIPTION
## Summary

- **Bug**: When running `gyre-server` on a non-default port (e.g. `GYRE_PORT=2223`), the CORS default origin list only included `2222`, `3000`, and `5173`. Browser preflight requests (triggered by `GET` + `Authorization` header) from `http://localhost:2223` would fail, causing 401 errors in the boss dashboard.
- **Fix**: `build_cors_layer()` now reads `GYRE_PORT` and appends `http://localhost:{port}` to the default allow-list when it isn't already present. Explicit `GYRE_CORS_ORIGINS` env var retains full precedence.
- **Test**: New integration test `cors_includes_server_port` in `api_integration.rs` verifies a CORS preflight `OPTIONS` request from the server's own origin receives the correct `Access-Control-Allow-Origin` response header.

## Test plan

- [x] `cargo build -p gyre-server` passes
- [x] `cargo test -p gyre-server --test api_integration cors_includes_server_port` — 1 passed
- [x] `cargo clippy` clean, `cargo fmt` clean
- [x] Existing 67 API integration tests unaffected

Closes TASK-122

🤖 Generated with [Claude Code](https://claude.com/claude-code)