### PR TITLE
feat(domain): add required field to QualityGate for advisory-only gates

### DIFF
--- a/crates/gyre-domain/src/quality_gate.rs
+++ b/crates/gyre-domain/src/quality_gate.rs
@@ -18,7 +18,15 @@ pub struct QualityGate {
     pub required_approvals: Option<u32>,
     /// Persona file path for AgentReview / AgentValidation gates.
     pub persona: Option<String>,
+    /// When false, a failing gate is advisory only — it does not block the MR from merging.
+    /// Defaults to true (blocking).
+    #[serde(default = "default_required")]
+    pub required: bool,
     pub created_at: u64,
+}
+
+fn default_required() -> bool {
+    true
 }
 
 /// Discriminant for a quality gate check type.

--- a/crates/gyre-server/src/api/gates.rs
+++ b/crates/gyre-server/src/api/gates.rs
@@ -30,6 +30,8 @@ pub struct CreateGateRequest {
     pub required_approvals: Option<u32>,
     /// Persona path (used by AgentReview / AgentValidation).
     pub persona: Option<String>,
+    /// When false, gate is advisory only — failures do not block merging. Defaults to true.
+    pub required: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -41,6 +43,8 @@ pub struct GateResponse {
     pub command: Option<String>,
     pub required_approvals: Option<u32>,
     pub persona: Option<String>,
+    /// Whether this gate is blocking (true) or advisory-only (false).
+    pub required: bool,
     pub created_at: u64,
 }
 
@@ -54,6 +58,7 @@ impl From<QualityGate> for GateResponse {
             command: g.command,
             required_approvals: g.required_approvals,
             persona: g.persona,
+            required: g.required,
             created_at: g.created_at,
         }
     }
@@ -208,6 +213,7 @@ pub async fn create_gate(
         command: req.command,
         required_approvals: req.required_approvals,
         persona: req.persona,
+        required: req.required.unwrap_or(true),
         created_at: now_secs(),
     };
 

--- a/crates/gyre-server/src/gate_executor.rs
+++ b/crates/gyre-server/src/gate_executor.rs
@@ -535,30 +535,48 @@ async fn run_command(cmd: &str) -> (GateStatus, String) {
     }
 }
 
-/// Returns whether all gate results for the given MR have passed.
-/// Returns `Ok(true)` if no gates exist or all passed.
-/// Returns `Ok(false)` if any are still pending/running.
-/// Returns `Err(msg)` if any gate has failed.
+/// Returns whether all required gate results for the given MR have passed.
+/// Returns `Ok(true)` if no gates exist or all required gates passed.
+/// Returns `Ok(false)` if any required gates are still pending/running.
+/// Returns `Err(msg)` if any required gate has failed.
+/// Non-required (advisory) gates that fail are recorded but do not block merging.
 pub async fn check_gates_for_mr(state: &AppState, mr_id: &Id) -> Result<bool, String> {
-    let lock = state.gate_results.lock().await;
-    let results: Vec<_> = lock
-        .values()
-        .filter(|r| r.mr_id.as_str() == mr_id.as_str())
-        .collect();
+    let results = {
+        let lock = state.gate_results.lock().await;
+        lock.values()
+            .filter(|r| r.mr_id.as_str() == mr_id.as_str())
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+
+    // Build a lookup of gate required-ness.
+    let gates = state.quality_gates.lock().await;
 
     for r in &results {
+        // Look up whether this gate is required (default: true for unknown gates).
+        let is_required = gates
+            .get(r.gate_id.as_str())
+            .map(|g| g.required)
+            .unwrap_or(true);
+
         match r.status {
             GateStatus::Failed => {
-                return Err(format!("gate {} failed", r.gate_id));
+                if is_required {
+                    return Err(format!("gate {} failed", r.gate_id));
+                }
+                // Advisory gate failure — log but don't block.
             }
             GateStatus::Pending | GateStatus::Running => {
-                return Ok(false); // not ready yet
+                if is_required {
+                    return Ok(false); // not ready yet
+                }
+                // Advisory gate still running — don't wait for it.
             }
             GateStatus::Passed => {}
         }
     }
 
-    Ok(true) // all passed (or no gates)
+    Ok(true) // all required gates passed (or no gates)
 }
 
 fn now_secs() -> u64 {
@@ -586,6 +604,7 @@ mod tests {
             command,
             required_approvals: None,
             persona: Some("personas/test.md".to_string()),
+            required: true,
             created_at: now_secs(),
         }
     }
@@ -814,5 +833,58 @@ mod tests {
         let result = check_gates_for_mr(&state, &mr_id).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains(gate_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn check_gates_non_required_failed_does_not_block() {
+        // A gate with required=false that fails should NOT block the MR.
+        let state = test_state();
+        let mr_id = make_mr_id();
+        let gate_id = Id::new(Uuid::new_v4().to_string());
+        let result_id = Id::new(Uuid::new_v4().to_string());
+
+        // Register the gate as advisory (required=false).
+        {
+            let mut gates = state.quality_gates.lock().await;
+            gates.insert(
+                gate_id.to_string(),
+                gyre_domain::QualityGate {
+                    id: gate_id.clone(),
+                    repo_id: Id::new(Uuid::new_v4().to_string()),
+                    name: "advisory-lint".to_string(),
+                    gate_type: GateType::LintCommand,
+                    command: Some("false".to_string()),
+                    required_approvals: None,
+                    persona: None,
+                    required: false,
+                    created_at: now_secs(),
+                },
+            );
+        }
+
+        // Record a Failed result for this advisory gate.
+        {
+            let mut lock = state.gate_results.lock().await;
+            lock.insert(
+                result_id.to_string(),
+                GateResult {
+                    id: result_id.clone(),
+                    gate_id: gate_id.clone(),
+                    mr_id: mr_id.clone(),
+                    status: GateStatus::Failed,
+                    output: Some("lint warnings".to_string()),
+                    started_at: None,
+                    finished_at: None,
+                },
+            );
+        }
+
+        // Non-required gate failure should return Ok(true) — MR can proceed.
+        let result = check_gates_for_mr(&state, &mr_id).await;
+        assert_eq!(
+            result,
+            Ok(true),
+            "advisory gate failure should not block MR"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `required: bool` field to `QualityGate` (serde default: `true`, backwards-compatible)
- When `required: false`, gate failures are advisory-only and do not block MR from merging
- `check_gates_for_mr` now skips non-required failed/pending results
- API accepts optional `required` in `CreateGateRequest` and exposes it in `GateResponse`
- New test: `check_gates_non_required_failed_does_not_block` verifies advisory gate behavior

## Test plan

- [x] `cargo test -p gyre-server gate` — 30/30 pass including new advisory gate test
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` — no drift
- [x] 3 gate integration tests pass (`quality_gates_create_list_delete`, `mr_gate_results`, `repos_push_gates_get_and_set`)

Closes TASK-124

🤖 Generated with [Claude Code](https://claude.com/claude-code)