### PR TITLE
feat(server): add warn_stale_spec + require_current_spec to SpecPolicy

### DIFF
--- a/crates/gyre-server/src/api/spec_policy.rs
+++ b/crates/gyre-server/src/api/spec_policy.rs
@@ -28,6 +28,14 @@ pub struct SpecPolicy {
     /// If true, MRs whose `spec_ref` has no active approval in the ledger are blocked.
     /// Implies `require_spec_ref` — both are checked when this is true.
     pub require_approved_spec: bool,
+    /// If true, emit a `StaleSpecWarning` domain event when an MR's spec_ref SHA is not
+    /// the current HEAD blob SHA for that spec file. Does not block the merge.
+    #[serde(default)]
+    pub warn_stale_spec: bool,
+    /// If true, block merging when an MR's spec_ref SHA is not the current HEAD blob SHA
+    /// for that spec file. Implies `require_spec_ref`.
+    #[serde(default)]
+    pub require_current_spec: bool,
 }
 
 #[derive(Serialize)]
@@ -35,6 +43,8 @@ pub struct SpecPolicyResponse {
     pub repo_id: String,
     pub require_spec_ref: bool,
     pub require_approved_spec: bool,
+    pub warn_stale_spec: bool,
+    pub require_current_spec: bool,
 }
 
 impl SpecPolicyResponse {
@@ -43,6 +53,8 @@ impl SpecPolicyResponse {
             repo_id,
             require_spec_ref: policy.require_spec_ref,
             require_approved_spec: policy.require_approved_spec,
+            warn_stale_spec: policy.warn_stale_spec,
+            require_current_spec: policy.require_current_spec,
         }
     }
 }
@@ -152,6 +164,106 @@ mod tests {
         let json = body_json(resp).await;
         assert!(!json["require_spec_ref"].as_bool().unwrap());
         assert!(!json["require_approved_spec"].as_bool().unwrap());
+        assert!(!json["warn_stale_spec"].as_bool().unwrap());
+        assert!(!json["require_current_spec"].as_bool().unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_warn_stale_spec_round_trips() {
+        let (app, _state) = app_with_repo();
+        let body = serde_json::json!({
+            "require_spec_ref": false,
+            "require_approved_spec": false,
+            "warn_stale_spec": true,
+            "require_current_spec": false
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/repos/repo-1/spec-policy")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(json["warn_stale_spec"].as_bool().unwrap());
+        assert!(!json["require_current_spec"].as_bool().unwrap());
+
+        // GET reflects persisted value.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/repos/repo-1/spec-policy")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(json["warn_stale_spec"].as_bool().unwrap());
+        assert!(!json["require_current_spec"].as_bool().unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_require_current_spec_round_trips() {
+        let (app, _state) = app_with_repo();
+        let body = serde_json::json!({
+            "require_spec_ref": false,
+            "require_approved_spec": false,
+            "warn_stale_spec": false,
+            "require_current_spec": true
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/repos/repo-1/spec-policy")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(!json["warn_stale_spec"].as_bool().unwrap());
+        assert!(json["require_current_spec"].as_bool().unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn new_fields_default_when_omitted_from_put() {
+        let (app, _state) = app_with_repo();
+        // Older client sends only the original two fields — new fields must default to false.
+        let body = serde_json::json!({
+            "require_spec_ref": true,
+            "require_approved_spec": false
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/repos/repo-1/spec-policy")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(json["require_spec_ref"].as_bool().unwrap());
+        assert!(!json["warn_stale_spec"].as_bool().unwrap());
+        assert!(!json["require_current_spec"].as_bool().unwrap());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/gyre-server/src/domain_events.rs
+++ b/crates/gyre-server/src/domain_events.rs
@@ -80,4 +80,13 @@ pub enum DomainEvent {
         spec_ref: Option<String>,
         gate_agent_id: String,
     },
+    /// Emitted when an MR references a spec_ref SHA that is not the current HEAD blob
+    /// for that spec file (warn_stale_spec policy). The merge is not blocked.
+    StaleSpecWarning {
+        mr_id: String,
+        repo_id: String,
+        spec_path: String,
+        spec_sha: String,
+        current_sha: String,
+    },
 }

--- a/crates/gyre-server/src/git_refs.rs
+++ b/crates/gyre-server/src/git_refs.rs
@@ -60,6 +60,34 @@ pub async fn write_ref(repo_path: &str, refname: &str, sha: &str) {
     }
 }
 
+/// Resolve the blob SHA for `file_path` at the current HEAD of `repo_path`.
+///
+/// Returns `None` if the file doesn't exist in HEAD, the repo is empty, or `file_path`
+/// contains unsafe characters that could cause argument injection.
+pub async fn resolve_blob_sha(repo_path: &str, file_path: &str) -> Option<String> {
+    // Reject paths that could inject git flags or traverse outside the tree.
+    if file_path.starts_with('-') || file_path.contains("..") {
+        tracing::warn!(file_path, "resolve_blob_sha: unsafe path rejected");
+        return None;
+    }
+    // Use "HEAD:<file_path>" as a single argument — git interprets this as a tree ref,
+    // not a flag, so no argument injection is possible.
+    let treeish = format!("HEAD:{file_path}");
+    let out = Command::new("git")
+        .args(["rev-parse", "--verify", &treeish])
+        .current_dir(repo_path)
+        .output()
+        .await
+        .ok()?;
+    if out.status.success() {
+        let sha = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Some(sha);
+        }
+    }
+    None
+}
+
 /// Count refs that exist under `prefix` (e.g. `refs/agents/{id}/snapshots/`).
 pub async fn count_refs_under(repo_path: &str, prefix: &str) -> usize {
     if !refname_safe(prefix) {

--- a/crates/gyre-server/src/merge_processor.rs
+++ b/crates/gyre-server/src/merge_processor.rs
@@ -279,6 +279,58 @@ async fn process_next(state: &AppState) -> anyhow::Result<()> {
                 }
             }
         }
+
+        // Check if the spec_ref SHA is current (warn_stale_spec / require_current_spec).
+        if policy.warn_stale_spec || policy.require_current_spec {
+            if let Some(spec_ref) = mr.spec_ref.as_deref() {
+                // Parse "path@sha" — same format used by verify_spec_ref.
+                if let Some((path, sha)) = spec_ref.rsplit_once('@') {
+                    let current = crate::git_refs::resolve_blob_sha(&repo.path, path).await;
+                    let is_stale = match &current {
+                        // If the file can't be resolved (new/empty repo), treat as non-stale.
+                        Some(cur) => cur != sha,
+                        None => false,
+                    };
+                    if is_stale {
+                        let current_sha = current.unwrap_or_default();
+                        if policy.require_current_spec {
+                            let reason = format!(
+                                "spec policy requires current spec: '{path}' HEAD is {current_sha} but MR references {sha}"
+                            );
+                            warn!(entry_id = %entry.id, %reason, "stale spec blocked merge");
+                            state
+                                .merge_queue
+                                .update_status(
+                                    &entry.id,
+                                    MergeQueueEntryStatus::Failed,
+                                    Some(reason),
+                                )
+                                .await?;
+                            return Ok(());
+                        } else {
+                            // warn_stale_spec only — emit domain event, don't block.
+                            warn!(
+                                entry_id = %entry.id,
+                                mr_id = %mr.id,
+                                spec_path = %path,
+                                spec_sha = %sha,
+                                %current_sha,
+                                "stale spec_ref detected (warn only)"
+                            );
+                            let _ = state.event_tx.send(
+                                crate::domain_events::DomainEvent::StaleSpecWarning {
+                                    mr_id: mr.id.to_string(),
+                                    repo_id: repo.id.to_string(),
+                                    spec_path: path.to_string(),
+                                    spec_sha: sha.to_string(),
+                                    current_sha,
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // Check quality gates before merging.


### PR DESCRIPTION
## Summary

- Extends `SpecPolicy` with `warn_stale_spec` (emit `StaleSpecWarning` domain event without blocking) and `require_current_spec` (reject MRs from merge queue when spec_ref SHA is stale)
- Adds `resolve_blob_sha` helper in `git_refs.rs` using `git rev-parse HEAD:<path>` (input sanitized — rejects paths starting with `-` or containing `..`)
- Adds `StaleSpecWarning` domain event variant broadcast via `event_tx`
- Both new fields use `#[serde(default)]` for backwards-compatible JSON deserialization

## Test plan

- [x] 6 unit tests in `api::spec_policy::tests` (all pass)
- [x] Full test suite clean (`cargo test --all`)
- [x] Clippy clean with `-D warnings`
- [x] Existing tests pass without modification (new fields default to false)

Closes TASK-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)