### PR TITLE
feat(server): M18 agent identity — OIDC provider + JWT agent tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,11 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 
 # JWT auth — disable default PEM support to avoid simple_asn1 → time 0.3.47 MSRV conflict.
 # Keys are loaded from DER bytes or JWK JSON (both work without the PEM feature).
+# Ring is always included as a transitive dep of jsonwebtoken (provides RSA/EC/EdDSA).
 jsonwebtoken = { version = "9", default-features = false }
+
+# Cryptographic primitives for agent JWT key generation (M18 OIDC provider).
+ring = "0.17"
 
 # ID generation
 uuid = { version = "1", features = ["v4"] }

--- a/crates/gyre-server/Cargo.toml
+++ b/crates/gyre-server/Cargo.toml
@@ -42,6 +42,8 @@ reqwest = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = "0.10"
 subtle = { workspace = true }
+ring = { workspace = true }
+base64 = "0.22"
 
 [dev-dependencies]
 tokio-tungstenite = "0.24"
@@ -49,9 +51,6 @@ http = "1"
 tower = { workspace = true, features = ["util"] }
 tempfile = "3"
 reqwest = { workspace = true, features = ["json"] }
-# ring for RSA JWT signing in tests (no simple_asn1 → time MSRV issue)
-ring = "0.17"
-base64 = "0.22"
 # For auth integration tests: seed users/api-keys and hash api keys.
 gyre-common = { workspace = true }
 gyre-ports = { workspace = true }

--- a/crates/gyre-server/src/api/auth.rs
+++ b/crates/gyre-server/src/api/auth.rs
@@ -1,13 +1,17 @@
-//! API key management endpoints.
+//! API key management and token introspection endpoints.
 //!
-//! `POST /api/v1/auth/api-keys` — create an API key (admin only).
+//! `POST /api/v1/auth/api-keys`  — create an API key (admin only).
+//! `GET  /api/v1/auth/token-info` — introspect the caller's current token (M18).
 
 use axum::{extract::State, http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::{auth::AdminOnly, AppState};
+use crate::{
+    auth::{AdminOnly, AuthenticatedAgent},
+    AppState,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct CreateApiKeyRequest {
@@ -49,6 +53,57 @@ pub async fn create_api_key(
             name: req.name,
         }),
     ))
+}
+
+// -- Token introspection ------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+pub struct TokenInfoResponse {
+    /// Resolved agent/user identity.
+    pub subject: String,
+    /// Roles granted to this token.
+    pub roles: Vec<String>,
+    /// Token kind: "global", "agent_jwt", "agent_uuid", "api_key", "keycloak_jwt".
+    pub token_kind: String,
+    /// JWT-specific claims, present when token_kind is "agent_jwt".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwt_claims: Option<crate::auth::AgentJwtClaims>,
+}
+
+/// GET /api/v1/auth/token-info
+///
+/// Introspects the caller's current auth token, returning the resolved identity
+/// and — for agent JWTs — the full decoded claims.
+pub async fn token_info(
+    auth: AuthenticatedAgent,
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<TokenInfoResponse>, (StatusCode, String)> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("");
+
+    let (token_kind, jwt_claims) = if token == state.auth_token {
+        ("global".to_string(), None)
+    } else if token.starts_with("ey") {
+        match state.agent_signing_key.validate(token, &state.base_url) {
+            Ok(claims) => ("agent_jwt".to_string(), Some(claims)),
+            Err(_) => ("keycloak_jwt".to_string(), None),
+        }
+    } else if token.starts_with("gyre_") {
+        ("api_key".to_string(), None)
+    } else {
+        ("agent_uuid".to_string(), None)
+    };
+
+    Ok(Json(TokenInfoResponse {
+        subject: auth.agent_id,
+        roles: auth.roles.iter().map(|r| r.as_str().to_string()).collect(),
+        token_kind,
+        jwt_claims,
+    }))
 }
 
 #[cfg(test)]

--- a/crates/gyre-server/src/api/mod.rs
+++ b/crates/gyre-server/src/api/mod.rs
@@ -258,8 +258,9 @@ pub fn api_router() -> Router<Arc<AppState>> {
         )
         .route("/api/v1/merge-queue", get(merge_queue::list_queue))
         .route("/api/v1/merge-queue/:id", delete(merge_queue::cancel_entry))
-        // Auth / API keys
+        // Auth / API keys / token introspection (M18)
         .route("/api/v1/auth/api-keys", post(auth::create_api_key))
+        .route("/api/v1/auth/token-info", get(auth::token_info))
         // Analytics
         .route(
             "/api/v1/analytics/events",

--- a/crates/gyre-server/src/api/spawn.rs
+++ b/crates/gyre-server/src/api/spawn.rs
@@ -100,8 +100,21 @@ pub async fn spawn_agent(
         .map_err(|e| ApiError::InvalidInput(e.to_string()))?;
     state.agents.create(&agent).await?;
 
-    // Generate auth token
-    let token = uuid::Uuid::new_v4().to_string();
+    // Mint a signed EdDSA JWT as the agent's auth token (M18).
+    // Falls back to a UUID if JWT minting fails (defensive).
+    let token = state
+        .agent_signing_key
+        .mint(
+            &agent.id.to_string(),
+            &task.id.to_string(),
+            &auth.agent_id,
+            &state.base_url,
+            state.agent_jwt_ttl_secs,
+        )
+        .unwrap_or_else(|e| {
+            tracing::error!("JWT minting failed, falling back to UUID token: {e}");
+            uuid::Uuid::new_v4().to_string()
+        });
     state
         .agent_tokens
         .lock()

--- a/crates/gyre-server/src/auth.rs
+++ b/crates/gyre-server/src/auth.rs
@@ -3,24 +3,142 @@
 //! Auth chain (first match wins):
 //! 1. Global `auth_token` -- for system/dev use, resolves as "system".
 //! 2. Per-agent tokens -- issued at registration, resolves as the agent id.
+//!    - UUID tokens: looked up in agent_tokens HashMap.
+//!    - JWT tokens (start with "ey"): looked up in HashMap + cryptographically validated.
 //! 3. API keys -- resolves as the owning user's name.
 //! 4. JWT (OIDC/Keycloak) -- validates RS256 token; auto-creates user on first login.
 //!
 //! If `jwt_config` is None the server runs without Keycloak (agent tokens only).
+//! Gyre always mints its own agent JWTs via `AgentSigningKey` (EdDSA/Ed25519).
 
 use axum::{
     extract::FromRequestParts,
     http::{request::Parts, StatusCode},
     response::{IntoResponse, Response},
 };
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use gyre_common::Id;
 use gyre_domain::{User, UserRole};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use std::{collections::HashMap, sync::Arc};
 use subtle::ConstantTimeEq;
 
 use crate::AppState;
+
+// -- Agent JWT signing (Gyre as OIDC provider) --------------------------------
+
+/// Claims embedded in agent JWTs minted by Gyre's built-in OIDC provider.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentJwtClaims {
+    /// Subject — the agent's UUID.
+    pub sub: String,
+    /// Issuer — the server's base URL.
+    pub iss: String,
+    /// Issued-at (Unix epoch seconds).
+    pub iat: u64,
+    /// Expiry (Unix epoch seconds).
+    pub exp: u64,
+    /// Always "agent" for agent tokens.
+    pub scope: String,
+    /// Task assigned to this agent at spawn time.
+    pub task_id: String,
+    /// Identity that called POST /api/v1/agents/spawn.
+    pub spawned_by: String,
+}
+
+/// Ed25519 key pair used to mint and verify agent JWTs.
+///
+/// Generated fresh on every server start. The public key is exposed via
+/// `GET /.well-known/jwks.json` so external verifiers can validate tokens.
+pub struct AgentSigningKey {
+    pub encoding_key: jsonwebtoken::EncodingKey,
+    pub decoding_key: jsonwebtoken::DecodingKey,
+    /// Pre-serialised JWKS JSON response body.
+    pub jwks_json: String,
+    /// Key ID embedded in JWT headers.
+    pub kid: String,
+}
+
+impl AgentSigningKey {
+    /// Generate a fresh Ed25519 key pair.
+    pub fn generate() -> Self {
+        use ring::rand::SystemRandom;
+        use ring::signature::Ed25519KeyPair;
+
+        let rng = SystemRandom::new();
+        let pkcs8 =
+            Ed25519KeyPair::generate_pkcs8(&rng).expect("Ed25519 key generation must succeed");
+        let key_pair = Ed25519KeyPair::from_pkcs8(pkcs8.as_ref())
+            .expect("Ed25519 key pair construction must succeed");
+        use ring::signature::KeyPair as _;
+        let pub_key_bytes = key_pair.public_key().as_ref();
+
+        let kid = uuid::Uuid::new_v4().to_string();
+        let x = URL_SAFE_NO_PAD.encode(pub_key_bytes);
+
+        let jwks_json = serde_json::json!({
+            "keys": [{
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "use": "sig",
+                "alg": "EdDSA",
+                "kid": kid,
+                "x": x
+            }]
+        })
+        .to_string();
+
+        let encoding_key = jsonwebtoken::EncodingKey::from_ed_der(pkcs8.as_ref());
+        let decoding_key = jsonwebtoken::DecodingKey::from_ed_der(pub_key_bytes);
+
+        Self {
+            encoding_key,
+            decoding_key,
+            jwks_json,
+            kid,
+        }
+    }
+
+    /// Mint a signed EdDSA JWT for an agent.
+    pub fn mint(
+        &self,
+        agent_id: &str,
+        task_id: &str,
+        spawned_by: &str,
+        issuer: &str,
+        ttl_secs: u64,
+    ) -> Result<String, String> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let claims = AgentJwtClaims {
+            sub: agent_id.to_string(),
+            iss: issuer.to_string(),
+            iat: now,
+            exp: now + ttl_secs,
+            scope: "agent".to_string(),
+            task_id: task_id.to_string(),
+            spawned_by: spawned_by.to_string(),
+        };
+        let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::EdDSA);
+        header.kid = Some(self.kid.clone());
+        jsonwebtoken::encode(&header, &claims, &self.encoding_key)
+            .map_err(|e| format!("JWT mint error: {e}"))
+    }
+
+    /// Validate a self-issued agent JWT, returning its claims on success.
+    pub fn validate(&self, token: &str, expected_issuer: &str) -> Result<AgentJwtClaims, String> {
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
+        validation.set_issuer(&[expected_issuer]);
+        validation.validate_aud = false;
+        jsonwebtoken::decode::<AgentJwtClaims>(token, &self.decoding_key, &validation)
+            .map(|td| td.claims)
+            .map_err(|e| format!("agent JWT validation: {e}"))
+    }
+}
 
 // -- Security helpers ---------------------------------------------------------
 
@@ -211,7 +329,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedAgent {
             });
         }
 
-        // 2. Per-agent tokens issued at registration.
+        // 2. Per-agent tokens issued at spawn (UUID legacy or JWT).
         {
             let agent_tokens = state.agent_tokens.lock().await;
             if let Some(agent_id) = agent_tokens
@@ -219,12 +337,39 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedAgent {
                 .find(|(_, t)| t.as_str() == token)
                 .map(|(id, _)| id.clone())
             {
+                // JWT tokens: additionally validate signature and expiry.
+                if token.starts_with("ey") {
+                    if let Err(e) = state.agent_signing_key.validate(token, &state.base_url) {
+                        tracing::debug!("Agent JWT validation failed: {e}");
+                        return Err((StatusCode::UNAUTHORIZED, "Invalid or expired agent token")
+                            .into_response());
+                    }
+                }
                 return Ok(AuthenticatedAgent {
                     agent_id,
                     user_id: None,
                     roles: vec![UserRole::Agent],
                     tenant_id: "default".to_string(),
                 });
+            }
+        }
+
+        // 2.5. JWT token not found in agent_tokens — treat as revoked or unknown.
+        //      Do not fall through to API-key or Keycloak for "ey" tokens,
+        //      as that would allow a compromised agent JWT to escalate.
+        if token.starts_with("ey") {
+            // Attempt cryptographic validation to give a better error message.
+            match state.agent_signing_key.validate(token, &state.base_url) {
+                Ok(_) => {
+                    // Valid signature but not in HashMap — token was revoked.
+                    return Err(
+                        (StatusCode::UNAUTHORIZED, "Agent token has been revoked").into_response()
+                    );
+                }
+                Err(_) => {
+                    // Invalid signature — fall through to Keycloak JWT path.
+                    // (Could be a legitimate Keycloak JWT that starts with "ey".)
+                }
             }
         }
 

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod messages;
 pub mod metrics;
 pub mod middleware;
 pub mod mirror_sync;
+pub(crate) mod oidc;
 pub mod pre_accept;
 pub mod rate_limit;
 pub(crate) mod rbac;
@@ -100,6 +101,11 @@ pub struct AppState {
     pub agent_messages: Arc<Mutex<HashMap<String, VecDeque<AgentMessage>>>>,
     /// Auth tokens issued on agent registration: agent_id -> token.
     pub agent_tokens: Arc<Mutex<HashMap<String, String>>>,
+    /// Ed25519 signing key for Gyre's built-in OIDC provider (M18).
+    /// Used to mint and verify agent JWTs returned by POST /api/v1/agents/spawn.
+    pub agent_signing_key: Arc<auth::AgentSigningKey>,
+    /// Agent JWT TTL in seconds. Configurable via GYRE_AGENT_JWT_TTL (default: 3600).
+    pub agent_jwt_ttl_secs: u64,
     /// User repository for JWT/SSO user management.
     pub users: Arc<dyn UserRepository>,
     /// API key repository: key -> user_id.
@@ -248,6 +254,12 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/healthz", get(health::healthz_handler))
         .route("/readyz", get(health::readyz_handler))
         .route("/metrics", get(metrics::metrics_handler))
+        // OIDC discovery endpoints (M18) — no auth required.
+        .route(
+            "/.well-known/openid-configuration",
+            get(oidc::openid_configuration),
+        )
+        .route("/.well-known/jwks.json", get(oidc::jwks))
         .route("/ws", get(ws::ws_handler))
         .route("/ws/agents/:id/tty", get(tty::tty_handler))
         // Git smart HTTP -- auth enforced per-handler via AuthenticatedAgent extractor.
@@ -391,6 +403,11 @@ pub fn build_state(
         event_tx,
         agent_messages: Arc::new(Mutex::new(HashMap::new())),
         agent_tokens: Arc::new(Mutex::new(HashMap::new())),
+        agent_signing_key: Arc::new(auth::AgentSigningKey::generate()),
+        agent_jwt_ttl_secs: std::env::var("GYRE_AGENT_JWT_TTL")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3600),
         users: store!(dyn UserRepository, mem::MemUserRepository::default()),
         api_keys: store!(dyn ApiKeyRepository, mem::MemApiKeyRepository::default()),
         jwt_config,

--- a/crates/gyre-server/src/mem.rs
+++ b/crates/gyre-server/src/mem.rs
@@ -1093,6 +1093,8 @@ pub fn test_state() -> Arc<crate::AppState> {
         event_tx: broadcast::channel(16).0,
         agent_messages: Arc::new(Mutex::new(HashMap::new())),
         agent_tokens: Arc::new(Mutex::new(HashMap::new())),
+        agent_signing_key: Arc::new(crate::auth::AgentSigningKey::generate()),
+        agent_jwt_ttl_secs: 3600,
         users: Arc::new(MemUserRepository::default()),
         api_keys: Arc::new(MemApiKeyRepository::default()),
         jwt_config: None,

--- a/crates/gyre-server/src/middleware.rs
+++ b/crates/gyre-server/src/middleware.rs
@@ -122,6 +122,8 @@ mod tests {
             broadcast_tx: base.broadcast_tx.clone(),
             agent_messages: base.agent_messages.clone(),
             agent_tokens: base.agent_tokens.clone(),
+            agent_signing_key: base.agent_signing_key.clone(),
+            agent_jwt_ttl_secs: base.agent_jwt_ttl_secs,
             users: base.users.clone(),
             api_keys: base.api_keys.clone(),
             jwt_config: base.jwt_config.clone(),

--- a/crates/gyre-server/src/oidc.rs
+++ b/crates/gyre-server/src/oidc.rs
@@ -1,0 +1,41 @@
+//! OIDC discovery endpoints (M18).
+//!
+//! Gyre acts as its own OIDC provider for agent tokens, exposing:
+//! - `GET /.well-known/openid-configuration` — standard discovery document
+//! - `GET /.well-known/jwks.json` — public Ed25519 key for JWT verification
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::AppState;
+
+/// GET /.well-known/openid-configuration
+///
+/// Returns a standard OIDC discovery document. External verifiers can use this
+/// to discover the JWKS URI and validate agent JWTs issued by Gyre.
+pub async fn openid_configuration(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let issuer = &state.base_url;
+    let doc = json!({
+        "issuer": issuer,
+        "jwks_uri": format!("{issuer}/.well-known/jwks.json"),
+        "token_endpoint": format!("{issuer}/api/v1/auth/token"),
+        "response_types_supported": ["token"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["EdDSA"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "scopes_supported": ["agent"],
+        "claims_supported": ["sub", "iss", "iat", "exp", "scope", "task_id", "spawned_by"]
+    });
+    (StatusCode::OK, Json(doc))
+}
+
+/// GET /.well-known/jwks.json
+///
+/// Returns the public Ed25519 key in JWK Set format. Third-party verifiers
+/// can use this key to validate agent JWTs without contacting Gyre.
+pub async fn jwks(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let jwks: serde_json::Value = serde_json::from_str(&state.agent_signing_key.jwks_json)
+        .unwrap_or_else(|_| json!({"keys": []}));
+    (StatusCode::OK, Json(jwks))
+}

--- a/crates/gyre-server/tests/m18_oidc_integration.rs
+++ b/crates/gyre-server/tests/m18_oidc_integration.rs
@@ -1,0 +1,443 @@
+//! M18 integration tests: OIDC provider + JWT agent tokens.
+//!
+//! Verifies:
+//! - `GET /.well-known/openid-configuration` returns valid OIDC discovery doc
+//! - `GET /.well-known/jwks.json` returns Ed25519 public key in JWK format
+//! - `POST /api/v1/agents/spawn` returns a JWT (starts with "ey")
+//! - JWT authenticates on subsequent API calls
+//! - Expired JWT is rejected after agent complete (token revocation)
+//! - `GET /api/v1/auth/token-info` introspects JWT agent tokens correctly
+
+use gyre_server::{build_router, build_state};
+
+const GLOBAL_TOKEN: &str = "m18-test-global-token";
+
+async fn start_server() -> (String, reqwest::Client) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let state = build_state(GLOBAL_TOKEN, &base_url, None);
+    let app = build_router(state);
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let client = reqwest::Client::new();
+    (base_url, client)
+}
+
+// -- OIDC discovery -----------------------------------------------------------
+
+#[tokio::test]
+async fn oidc_discovery_document_is_valid() {
+    let (base, client) = start_server().await;
+    let resp = client
+        .get(format!("{base}/.well-known/openid-configuration"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "OIDC discovery must return 200");
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["issuer"], base, "issuer must equal base_url");
+    assert!(
+        body["jwks_uri"]
+            .as_str()
+            .unwrap()
+            .ends_with("/.well-known/jwks.json"),
+        "jwks_uri must point to JWKS endpoint"
+    );
+    assert!(
+        body["id_token_signing_alg_values_supported"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("EdDSA")),
+        "must advertise EdDSA"
+    );
+}
+
+#[tokio::test]
+async fn oidc_discovery_requires_no_auth() {
+    let (base, client) = start_server().await;
+    // No Authorization header — must still return 200.
+    let resp = client
+        .get(format!("{base}/.well-known/openid-configuration"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn jwks_endpoint_returns_ed25519_key() {
+    let (base, client) = start_server().await;
+    let resp = client
+        .get(format!("{base}/.well-known/jwks.json"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "JWKS endpoint must return 200");
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let keys = body["keys"].as_array().expect("must have 'keys' array");
+    assert_eq!(keys.len(), 1, "must have exactly one key");
+
+    let key = &keys[0];
+    assert_eq!(key["kty"], "OKP", "kty must be OKP");
+    assert_eq!(key["crv"], "Ed25519", "crv must be Ed25519");
+    assert_eq!(key["alg"], "EdDSA", "alg must be EdDSA");
+    assert_eq!(key["use"], "sig", "use must be sig");
+    assert!(key["kid"].is_string(), "kid must be present");
+    assert!(key["x"].is_string(), "x (public key) must be present");
+}
+
+// -- JWT agent token issuance -------------------------------------------------
+
+#[tokio::test]
+async fn spawn_returns_jwt_token() {
+    let (base, client) = start_server().await;
+
+    // Create project, repo, task.
+    let proj: serde_json::Value = client
+        .post(format!("{base}/api/v1/projects"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "m18-proj", "description": ""}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let proj_id = proj["id"].as_str().unwrap();
+
+    let repo: serde_json::Value = client
+        .post(format!("{base}/api/v1/repos"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "m18-repo", "project_id": proj_id}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let repo_id = repo["id"].as_str().unwrap();
+
+    let task: serde_json::Value = client
+        .post(format!("{base}/api/v1/tasks"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"title": "M18 task", "description": "", "priority": "medium", "status": "todo"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    // Spawn agent.
+    let spawn_resp = client
+        .post(format!("{base}/api/v1/agents/spawn"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({
+            "name": "m18-agent",
+            "repo_id": repo_id,
+            "task_id": task_id,
+            "branch": "feat/m18-test"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(spawn_resp.status(), 201, "spawn must return 201");
+
+    let spawn_json: serde_json::Value = spawn_resp.json().await.unwrap();
+    let token = spawn_json["token"].as_str().unwrap();
+
+    // JWT tokens start with "ey" (base64url-encoded header).
+    assert!(
+        token.starts_with("ey"),
+        "spawn token must be a JWT (starts with 'ey'), got: {token}"
+    );
+
+    // JWT must have 3 dot-separated parts.
+    let parts: Vec<&str> = token.split('.').collect();
+    assert_eq!(parts.len(), 3, "JWT must have 3 parts separated by '.'");
+}
+
+#[tokio::test]
+async fn jwt_token_authenticates_api_calls() {
+    let (base, client) = start_server().await;
+
+    // Setup project/repo/task.
+    let proj: serde_json::Value = client
+        .post(format!("{base}/api/v1/projects"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "jwt-auth-proj", "description": ""}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let proj_id = proj["id"].as_str().unwrap();
+
+    let repo: serde_json::Value = client
+        .post(format!("{base}/api/v1/repos"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "jwt-auth-repo", "project_id": proj_id}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let repo_id = repo["id"].as_str().unwrap();
+
+    let task: serde_json::Value = client
+        .post(format!("{base}/api/v1/tasks"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"title": "jwt auth task", "description": "", "priority": "medium", "status": "todo"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    let spawn_json: serde_json::Value = client
+        .post(format!("{base}/api/v1/agents/spawn"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({
+            "name": "jwt-auth-agent",
+            "repo_id": repo_id,
+            "task_id": task_id,
+            "branch": "feat/jwt-auth-test"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let jwt_token = spawn_json["token"].as_str().unwrap();
+    assert!(jwt_token.starts_with("ey"), "token must be JWT");
+
+    // Use the JWT to list projects (should succeed).
+    let list_resp = client
+        .get(format!("{base}/api/v1/projects"))
+        .header("Authorization", format!("Bearer {jwt_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        list_resp.status(),
+        200,
+        "JWT token must authenticate API calls"
+    );
+}
+
+// -- Token introspection ------------------------------------------------------
+
+#[tokio::test]
+async fn token_info_for_jwt_agent_token() {
+    let (base, client) = start_server().await;
+
+    // Setup and spawn.
+    let proj: serde_json::Value = client
+        .post(format!("{base}/api/v1/projects"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "info-proj", "description": ""}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let proj_id = proj["id"].as_str().unwrap();
+
+    let repo: serde_json::Value = client
+        .post(format!("{base}/api/v1/repos"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "info-repo", "project_id": proj_id}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let repo_id = repo["id"].as_str().unwrap();
+
+    let task: serde_json::Value = client
+        .post(format!("{base}/api/v1/tasks"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"title": "info task", "description": "", "priority": "low", "status": "todo"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    let spawn_json: serde_json::Value = client
+        .post(format!("{base}/api/v1/agents/spawn"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({
+            "name": "info-agent",
+            "repo_id": repo_id,
+            "task_id": task_id,
+            "branch": "feat/info-test"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let jwt_token = spawn_json["token"].as_str().unwrap();
+    let agent_id = spawn_json["agent"]["id"].as_str().unwrap();
+
+    // Call token-info with the agent JWT.
+    let info_resp = client
+        .get(format!("{base}/api/v1/auth/token-info"))
+        .header("Authorization", format!("Bearer {jwt_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(info_resp.status(), 200, "token-info must return 200");
+
+    let info: serde_json::Value = info_resp.json().await.unwrap();
+    assert_eq!(
+        info["token_kind"], "agent_jwt",
+        "token_kind must be agent_jwt"
+    );
+    assert_eq!(
+        info["subject"].as_str().unwrap(),
+        agent_id,
+        "subject must be agent id"
+    );
+    // JWT claims should be present.
+    let claims = &info["jwt_claims"];
+    assert!(
+        claims.is_object(),
+        "jwt_claims must be present for JWT tokens"
+    );
+    assert_eq!(claims["sub"].as_str().unwrap(), agent_id);
+    assert_eq!(claims["scope"].as_str().unwrap(), "agent");
+    assert_eq!(claims["task_id"].as_str().unwrap(), task_id);
+}
+
+#[tokio::test]
+async fn token_info_for_global_token() {
+    let (base, client) = start_server().await;
+    let resp = client
+        .get(format!("{base}/api/v1/auth/token-info"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let info: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(info["token_kind"], "global");
+    assert_eq!(info["subject"], "system");
+}
+
+// -- Revocation after complete ------------------------------------------------
+
+#[tokio::test]
+async fn jwt_revoked_after_agent_complete() {
+    let (base, client) = start_server().await;
+
+    let proj: serde_json::Value = client
+        .post(format!("{base}/api/v1/projects"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "revoke-proj", "description": ""}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let proj_id = proj["id"].as_str().unwrap();
+
+    let repo: serde_json::Value = client
+        .post(format!("{base}/api/v1/repos"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"name": "revoke-repo", "project_id": proj_id}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let repo_id = repo["id"].as_str().unwrap();
+
+    let task: serde_json::Value = client
+        .post(format!("{base}/api/v1/tasks"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({"title": "revoke task", "description": "", "priority": "medium", "status": "todo"}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let task_id = task["id"].as_str().unwrap();
+
+    let spawn_json: serde_json::Value = client
+        .post(format!("{base}/api/v1/agents/spawn"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({
+            "name": "revoke-agent",
+            "repo_id": repo_id,
+            "task_id": task_id,
+            "branch": "feat/revoke-test"
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let jwt_token = spawn_json["token"].as_str().unwrap().to_string();
+    let agent_id = spawn_json["agent"]["id"].as_str().unwrap().to_string();
+
+    // Verify JWT works before complete.
+    let pre = client
+        .get(format!("{base}/api/v1/projects"))
+        .header("Authorization", format!("Bearer {jwt_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(pre.status(), 200, "JWT must work before complete");
+
+    // Complete the agent.
+    let complete_resp = client
+        .post(format!("{base}/api/v1/agents/{agent_id}/complete"))
+        .header("Authorization", format!("Bearer {GLOBAL_TOKEN}"))
+        .json(&serde_json::json!({
+            "branch": "feat/revoke-test",
+            "title": "Revoke test MR",
+            "target_branch": "main"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        complete_resp.status().is_success(),
+        "complete must return 2xx, got {}",
+        complete_resp.status()
+    );
+
+    // JWT must now be rejected.
+    let post = client
+        .get(format!("{base}/api/v1/projects"))
+        .header("Authorization", format!("Bearer {jwt_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        post.status(),
+        401,
+        "JWT must be rejected after agent complete"
+    );
+}


### PR DESCRIPTION
## Summary

- **OIDC Provider**: Gyre now acts as its own OIDC provider, generating an Ed25519 key pair on startup and exposing `GET /.well-known/openid-configuration` and `GET /.well-known/jwks.json` endpoints
- **JWT Agent Tokens**: `POST /api/v1/agents/spawn` now returns a signed EdDSA JWT instead of an opaque UUID, containing claims: `sub` (agent_id), `iss` (base_url), `iat`, `exp`, `scope="agent"`, `task_id`, `spawned_by`
- **Auth chain upgrade**: JWTs are validated cryptographically (signature + expiry) AND checked against the agent_tokens HashMap for revocation; revoked JWTs (after agent complete) return 401
- **Token introspection**: `GET /api/v1/auth/token-info` returns token kind and decoded JWT claims
- **Backward compatible**: Legacy UUID tokens still work; external Keycloak JWTs still work
- **Configurable TTL**: `GYRE_AGENT_JWT_TTL` env var (default: 3600s)

## Test plan

- [x] 8 new M18 integration tests (`tests/m18_oidc_integration.rs`)
- [x] OIDC discovery document shape + no-auth access
- [x] JWKS endpoint returns Ed25519 OKP JWK with correct fields
- [x] spawn returns JWT (starts with "ey", 3 dot-separated parts)
- [x] JWT authenticates subsequent API calls
- [x] `token-info` returns `agent_jwt` kind + decoded claims including `task_id`
- [x] JWT revoked after agent complete (401 on re-use)
- [x] All 394 lib tests pass
- [x] All 67 API integration tests pass
- [x] All 21 auth integration tests pass
- [x] Clippy clean

Closes TASK-125

🤖 Generated with [Claude Code](https://claude.com/claude-code)