### PR TITLE
feat(server): G5 merge attestation bundles — signed JSON on merge commits

### DIFF
--- a/crates/gyre-server/src/api/merge_requests.rs
+++ b/crates/gyre-server/src/api/merge_requests.rs
@@ -664,6 +664,31 @@ pub async fn get_diff(
     }))
 }
 
+// ── Attestation ───────────────────────────────────────────────────────────────
+
+/// `GET /api/v1/merge-requests/{id}/attestation`
+///
+/// Returns the signed attestation bundle created at merge time (G5).
+/// Returns 404 if the MR does not exist or has not yet been merged.
+pub async fn get_attestation(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<crate::attestation::AttestationBundle>, ApiError> {
+    // Verify the MR exists.
+    state
+        .merge_requests
+        .find_by_id(&Id::new(&id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("merge request {id} not found")))?;
+
+    let store = state.attestation_store.lock().await;
+    store
+        .get(&id)
+        .cloned()
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound(format!("no attestation found for merge request {id}")))
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1012,5 +1037,123 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ── Attestation tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn attestation_missing_mr_returns_404() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/merge-requests/no-such-mr/attestation")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn attestation_unmerged_mr_returns_404() {
+        let app = app();
+        let (app, id) = create_test_mr(app, "Not yet merged").await;
+
+        // MR exists but has no attestation yet (not merged)
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/merge-requests/{id}/attestation"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn attestation_bundle_round_trip() {
+        use crate::attestation::{sign_attestation, verify_bundle, MergeAttestation};
+        use crate::mem::test_state;
+
+        let state = test_state();
+
+        // Build and sign an attestation.
+        let attestation = MergeAttestation {
+            attestation_version: 1,
+            mr_id: "mr-abc".to_string(),
+            merge_commit_sha: "deadbeef".repeat(5),
+            merged_at: 1_700_000_000,
+            gate_results: vec![],
+            spec_ref: None,
+            spec_fully_approved: true,
+            author_agent_id: Some("agent-1".to_string()),
+        };
+
+        let bundle = sign_attestation(attestation, &state.agent_signing_key);
+
+        // Signature must verify with the public key.
+        assert!(verify_bundle(
+            &bundle,
+            &state.agent_signing_key.public_key_bytes
+        ));
+
+        // Tampered payload must fail verification.
+        let mut tampered = bundle.clone();
+        tampered.attestation.merge_commit_sha = "000000".to_string();
+        assert!(!verify_bundle(
+            &tampered,
+            &state.agent_signing_key.public_key_bytes
+        ));
+    }
+
+    #[tokio::test]
+    async fn attestation_stored_and_retrievable() {
+        use crate::attestation::{sign_attestation, MergeAttestation};
+        use crate::mem::test_state;
+
+        let state = test_state();
+
+        // Create an MR so the GET endpoint can find it.
+        let app = crate::api::api_router().with_state(state.clone());
+        let (app, mr_id) = create_test_mr(app, "Merge me").await;
+
+        // Directly insert an attestation bundle into the store.
+        let attestation = MergeAttestation {
+            attestation_version: 1,
+            mr_id: mr_id.clone(),
+            merge_commit_sha: "abc123".to_string(),
+            merged_at: 1_700_000_000,
+            gate_results: vec![],
+            spec_ref: None,
+            spec_fully_approved: true,
+            author_agent_id: None,
+        };
+        let bundle = sign_attestation(attestation, &state.agent_signing_key);
+        {
+            let mut store = state.attestation_store.lock().await;
+            store.insert(mr_id.clone(), bundle.clone());
+        }
+
+        // GET the attestation via the API.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/merge-requests/{mr_id}/attestation"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let json = body_json(resp).await;
+        assert_eq!(json["attestation"]["mr_id"], mr_id);
+        assert_eq!(json["attestation"]["merge_commit_sha"], "abc123");
+        assert_eq!(json["attestation"]["attestation_version"], 1);
+        assert!(json["signature"].as_str().is_some());
+        assert!(json["signing_key_id"].as_str().is_some());
     }
 }

--- a/crates/gyre-server/src/api/mod.rs
+++ b/crates/gyre-server/src/api/mod.rs
@@ -228,6 +228,10 @@ pub fn api_router() -> Router<Arc<AppState>> {
             get(merge_requests::get_diff),
         )
         .route(
+            "/api/v1/merge-requests/:id/attestation",
+            get(merge_requests::get_attestation),
+        )
+        .route(
             "/api/v1/merge-requests/:id/gates",
             get(gates::list_mr_gate_results),
         )

--- a/crates/gyre-server/src/attestation.rs
+++ b/crates/gyre-server/src/attestation.rs
@@ -1,0 +1,90 @@
+//! Merge attestation bundles (G5).
+//!
+//! After every successful merge the merge processor assembles a `MergeAttestation`
+//! record containing the MR ID, merge commit SHA, gate results, spec approval
+//! status, and author identity.  The record is canonicalised to JSON, signed with
+//! the server's Ed25519 key, wrapped in an `AttestationBundle`, stored in the
+//! in-memory `attestation_store`, and attached to the merge commit as a git note
+//! under `refs/notes/attestations`.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde::{Deserialize, Serialize};
+
+// ── Data types ───────────────────────────────────────────────────────────────
+
+/// Snapshot of a single gate result captured at merge time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttestationGateResult {
+    pub gate_id: String,
+    pub gate_type: String,
+    pub status: String,
+    pub output: Option<String>,
+}
+
+/// The attestation payload for one merge event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeAttestation {
+    /// Gyre attestation format version.
+    pub attestation_version: u32,
+    pub mr_id: String,
+    pub merge_commit_sha: String,
+    /// Unix epoch seconds when the merge was recorded.
+    pub merged_at: u64,
+    /// Gate results at the time of merge.
+    pub gate_results: Vec<AttestationGateResult>,
+    /// Spec reference bound to this MR (e.g. `"specs/system/foo.md@<sha>"`), if any.
+    pub spec_ref: Option<String>,
+    /// Whether every referenced spec had an active (non-revoked) approval at merge time.
+    pub spec_fully_approved: bool,
+    /// Agent ID of the MR author.
+    pub author_agent_id: Option<String>,
+}
+
+/// Signed attestation bundle returned by `GET /api/v1/merge-requests/{id}/attestation`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttestationBundle {
+    pub attestation: MergeAttestation,
+    /// Base64-encoded Ed25519 signature over the canonical JSON of `attestation`.
+    pub signature: String,
+    /// `kid` of the Ed25519 key that produced `signature` (matches JWKS endpoint).
+    pub signing_key_id: String,
+}
+
+// ── Signing ──────────────────────────────────────────────────────────────────
+
+/// Sign `attestation` with `signing_key` and return an `AttestationBundle`.
+///
+/// The canonical form is deterministic JSON (struct field order as declared).
+/// The signature covers the UTF-8 bytes of that JSON.
+pub fn sign_attestation(
+    attestation: MergeAttestation,
+    signing_key: &crate::auth::AgentSigningKey,
+) -> AttestationBundle {
+    let canonical =
+        serde_json::to_string(&attestation).expect("MergeAttestation serialisation must not fail");
+    let raw_sig = signing_key.sign_bytes(canonical.as_bytes());
+    let signature = BASE64.encode(&raw_sig);
+    let signing_key_id = signing_key.kid.clone();
+    AttestationBundle {
+        attestation,
+        signature,
+        signing_key_id,
+    }
+}
+
+/// Verify a bundle's signature using the provided raw 32-byte Ed25519 public key.
+///
+/// Returns `true` if the signature is valid.
+pub fn verify_bundle(bundle: &AttestationBundle, public_key_bytes: &[u8]) -> bool {
+    use ring::signature::{self, UnparsedPublicKey};
+    let canonical = match serde_json::to_string(&bundle.attestation) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let sig_bytes = match BASE64.decode(&bundle.signature) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let pk = UnparsedPublicKey::new(&signature::ED25519, public_key_bytes);
+    pk.verify(canonical.as_bytes(), &sig_bytes).is_ok()
+}

--- a/crates/gyre-server/src/auth.rs
+++ b/crates/gyre-server/src/auth.rs
@@ -59,6 +59,10 @@ pub struct AgentSigningKey {
     pub jwks_json: String,
     /// Key ID embedded in JWT headers.
     pub kid: String,
+    /// Raw PKCS#8 bytes retained for signing arbitrary data (attestation bundles).
+    pkcs8_bytes: Vec<u8>,
+    /// Raw 32-byte public key for external verification.
+    pub public_key_bytes: Vec<u8>,
 }
 
 impl AgentSigningKey {
@@ -98,7 +102,19 @@ impl AgentSigningKey {
             decoding_key,
             jwks_json,
             kid,
+            pkcs8_bytes: pkcs8.as_ref().to_vec(),
+            public_key_bytes: pub_key_bytes.to_vec(),
         }
+    }
+
+    /// Sign arbitrary bytes with the Ed25519 private key.
+    ///
+    /// Used by the attestation module to sign merge attestation bundles.
+    pub fn sign_bytes(&self, data: &[u8]) -> Vec<u8> {
+        use ring::signature::Ed25519KeyPair;
+        let key_pair = Ed25519KeyPair::from_pkcs8(&self.pkcs8_bytes)
+            .expect("stored pkcs8 bytes must remain valid");
+        key_pair.sign(data).as_ref().to_vec()
     }
 
     /// Mint a signed EdDSA JWT for an agent.
@@ -535,7 +551,7 @@ impl FromRequestParts<Arc<AppState>> for AdminOnly {
 pub mod test_helpers {
     use super::*;
     use crate::JwtConfig;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use jsonwebtoken::DecodingKey;
     use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub(crate) mod activity;
 pub mod api;
+pub mod attestation;
 pub mod audit_simulator;
 pub(crate) mod auth;
 pub mod domain_events;
@@ -171,6 +172,8 @@ pub struct AppState {
     pub spec_approvals: Arc<Mutex<HashMap<String, gyre_domain::SpecApproval>>>,
     /// Per-repo spec enforcement policies: repo_id -> SpecPolicy (M12.3).
     pub spec_policies: Arc<Mutex<HashMap<String, api::spec_policy::SpecPolicy>>>,
+    /// Merge attestation bundles: mr_id -> AttestationBundle (G5).
+    pub attestation_store: Arc<Mutex<HashMap<String, attestation::AttestationBundle>>>,
 }
 
 /// Global authentication middleware for all `/api/v1/` routes.
@@ -468,6 +471,7 @@ pub fn build_state(
         db_storage,
         spec_approvals: Arc::new(Mutex::new(HashMap::new())),
         spec_policies: Arc::new(Mutex::new(HashMap::new())),
+        attestation_store: Arc::new(Mutex::new(HashMap::new())),
     })
 }
 

--- a/crates/gyre-server/src/mem.rs
+++ b/crates/gyre-server/src/mem.rs
@@ -1130,5 +1130,6 @@ pub fn test_state() -> Arc<crate::AppState> {
         db_storage: None,
         spec_approvals: Arc::new(Mutex::new(HashMap::new())),
         spec_policies: Arc::new(Mutex::new(HashMap::new())),
+        attestation_store: Arc::new(Mutex::new(HashMap::new())),
     })
 }

--- a/crates/gyre-server/src/merge_processor.rs
+++ b/crates/gyre-server/src/merge_processor.rs
@@ -403,6 +403,101 @@ async fn process_next(state: &AppState) -> anyhow::Result<()> {
                 now,
             );
             let _ = state.analytics.record(&ev).await;
+
+            // Build and store a signed merge attestation bundle (G5).
+            let gate_results_snapshot = {
+                let lock = state.gate_results.lock().await;
+                lock.values()
+                    .filter(|r| r.mr_id.as_str() == updated_mr.id.as_str())
+                    .map(|r| crate::attestation::AttestationGateResult {
+                        gate_id: r.gate_id.to_string(),
+                        gate_type: String::new(), // gate type looked up below
+                        status: format!("{:?}", r.status),
+                        output: r.output.clone(),
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            // Enrich gate_type from quality_gates map.
+            let gate_results_enriched = {
+                let gates_lock = state.quality_gates.lock().await;
+                gate_results_snapshot
+                    .into_iter()
+                    .map(|mut gr| {
+                        if let Some(gate) = gates_lock.get(&gr.gate_id) {
+                            gr.gate_type = format!("{:?}", gate.gate_type);
+                        }
+                        gr
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            // Check spec approval status.
+            let spec_fully_approved = if let Some(spec_ref) = updated_mr.spec_ref.as_deref() {
+                crate::api::gates::verify_spec_ref(state, spec_ref)
+                    .await
+                    .is_ok()
+            } else {
+                true // no spec bound — treat as approved
+            };
+
+            let attestation = crate::attestation::MergeAttestation {
+                attestation_version: 1,
+                mr_id: updated_mr.id.to_string(),
+                merge_commit_sha: merge_commit_sha.clone(),
+                merged_at: now,
+                gate_results: gate_results_enriched,
+                spec_ref: updated_mr.spec_ref.clone(),
+                spec_fully_approved,
+                author_agent_id: updated_mr.author_agent_id.as_ref().map(|id| id.to_string()),
+            };
+
+            let bundle =
+                crate::attestation::sign_attestation(attestation, &state.agent_signing_key);
+
+            // Attach as a git note under refs/notes/attestations.
+            let bundle_json = serde_json::to_string(&bundle).unwrap_or_default();
+            let repo_path = repo.path.clone();
+            let sha_for_note = merge_commit_sha.clone();
+            let bundle_json_for_note = bundle_json.clone();
+            tokio::spawn(async move {
+                let out = tokio::process::Command::new("git")
+                    .args([
+                        "-C",
+                        &repo_path,
+                        "notes",
+                        "--ref=refs/notes/attestations",
+                        "add",
+                        "-f",
+                        "-m",
+                        &bundle_json_for_note,
+                        &sha_for_note,
+                    ])
+                    .output()
+                    .await;
+                match out {
+                    Ok(o) if o.status.success() => {
+                        tracing::info!(sha = %sha_for_note, "attestation note attached");
+                    }
+                    Ok(o) => {
+                        tracing::warn!(
+                            sha = %sha_for_note,
+                            stderr = %String::from_utf8_lossy(&o.stderr),
+                            "git notes failed — attestation stored in memory only"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(sha = %sha_for_note, error = %e, "git not found — attestation stored in memory only");
+                    }
+                }
+            });
+
+            // Store in memory for API retrieval.
+            {
+                let mut store = state.attestation_store.lock().await;
+                store.insert(updated_mr.id.to_string(), bundle);
+            }
+            info!(mr_id = %updated_mr.id, sha = %merge_commit_sha, "attestation bundle created and stored");
         }
         Ok(MergeResult::Conflict { message }) => {
             warn!(entry_id = %entry.id, reason = %message, "merge conflict");

--- a/crates/gyre-server/src/middleware.rs
+++ b/crates/gyre-server/src/middleware.rs
@@ -156,6 +156,7 @@ mod tests {
             db_storage: base.db_storage.clone(),
             spec_approvals: base.spec_approvals.clone(),
             spec_policies: base.spec_policies.clone(),
+            attestation_store: base.attestation_store.clone(),
         });
         crate::build_router(state)
     }


### PR DESCRIPTION
## Summary

- Implements **G5**: after every successful merge the merge processor assembles a signed `MergeAttestation` and attaches it as a git note under `refs/notes/attestations`
- New `attestation.rs` module: `MergeAttestation`, `AttestationBundle`, `sign_attestation()`, `verify_bundle()`
- `AgentSigningKey` extended with `sign_bytes()` (raw Ed25519 via ring) + `public_key_bytes` for external verification
- New API endpoint: `GET /api/v1/merge-requests/{id}/attestation` — returns the signed bundle for a merged MR
- Bundles stored in in-memory `attestation_store` on `AppState` (keyed by `mr_id`)
- Git note attachment via `git notes --ref=refs/notes/attestations add -f -m <json> <sha>` (non-blocking; falls back gracefully if git unavailable)

## Attestation payload fields

| Field | Description |
|---|---|
| `attestation_version` | Always `1` for this implementation |
| `mr_id` | UUID of the merged MR |
| `merge_commit_sha` | SHA of the merge commit |
| `merged_at` | Unix epoch seconds |
| `gate_results` | Snapshot of gate status at merge time |
| `spec_ref` | Spec binding string (`path@sha`), if any |
| `spec_fully_approved` | Whether the spec had active approval |
| `author_agent_id` | MR author agent ID |

## Test plan

- [x] `attestation_bundle_round_trip`: sign + verify passes; tampered payload fails
- [x] `attestation_stored_and_retrievable`: bundle stored → API returns 200 with correct fields
- [x] `attestation_unmerged_mr_returns_404`: MR exists but no attestation yet
- [x] `attestation_missing_mr_returns_404`: non-existent MR
- [x] All 402 lib tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)