### PR TITLE
feat(server): M13.8 — local Sigstore signing on jj squash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/crates/gyre-adapters/src/jj_ops.rs
+++ b/crates/gyre-adapters/src/jj_ops.rs
@@ -113,9 +113,25 @@ impl JjOpsPort for JjOpsAdapter {
         Ok(changes)
     }
 
-    async fn jj_squash(&self, repo_path: &str) -> Result<()> {
+    async fn jj_squash(&self, repo_path: &str) -> Result<String> {
         self.run_jj(repo_path, &["squash"]).await?;
-        Ok(())
+        // After squash the parent becomes the working copy — get its commit SHA.
+        let sha = self
+            .run_jj(
+                repo_path,
+                &[
+                    "log",
+                    "--no-graph",
+                    "--color",
+                    "never",
+                    "--limit",
+                    "1",
+                    "-T",
+                    "commit_id",
+                ],
+            )
+            .await?;
+        Ok(sha.trim().to_string())
     }
 
     async fn jj_bookmark_create(&self, repo_path: &str, name: &str, change_id: &str) -> Result<()> {

--- a/crates/gyre-ports/src/jj_ops.rs
+++ b/crates/gyre-ports/src/jj_ops.rs
@@ -33,7 +33,9 @@ pub trait JjOpsPort: Send + Sync {
     async fn jj_log(&self, repo_path: &str, limit: usize) -> Result<Vec<JjChange>>;
 
     /// Squash the working copy into its parent change.
-    async fn jj_squash(&self, repo_path: &str) -> Result<()>;
+    ///
+    /// Returns the commit SHA of the resulting (parent) commit after squash.
+    async fn jj_squash(&self, repo_path: &str) -> Result<String>;
 
     /// Create a bookmark (branch) pointing to a specific change.
     async fn jj_bookmark_create(&self, repo_path: &str, name: &str, change_id: &str) -> Result<()>;

--- a/crates/gyre-server/src/api/jj.rs
+++ b/crates/gyre-server/src/api/jj.rs
@@ -8,6 +8,7 @@ use gyre_ports::JjChange;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use crate::commit_signatures::{self, CommitSignature};
 use crate::AppState;
 
 use super::error::ApiError;
@@ -106,17 +107,60 @@ pub async fn jj_new(
 }
 
 /// POST /api/v1/repos/:id/jj/squash
+///
+/// Squashes the working copy into its parent change and signs the resulting
+/// commit SHA with the forge's Ed25519 key (M13.8 Sigstore local signing).
 pub async fn jj_squash(
     State(state): State<Arc<AppState>>,
     Path(repo_id): Path<String>,
-) -> Result<StatusCode, ApiError> {
+) -> Result<Json<CommitSignature>, ApiError> {
     let path = repo_path(&state, &repo_id).await?;
-    state
+    let commit_sha = state
         .jj_ops
         .jj_squash(&path)
         .await
         .map_err(ApiError::Internal)?;
-    Ok(StatusCode::NO_CONTENT)
+
+    // Sign the resulting commit SHA with the forge's Ed25519 key.
+    let record = commit_signatures::sign_commit(
+        &commit_sha,
+        "forge",
+        &state.agent_signing_key,
+        state.sigstore_mode.clone(),
+    );
+
+    state
+        .commit_signatures
+        .lock()
+        .await
+        .insert(commit_sha.clone(), record.clone());
+
+    tracing::info!(
+        commit_sha = %commit_sha,
+        signing_key_id = %record.signing_key_id,
+        mode = ?record.sigstore_mode,
+        "jj squash: commit signed (M13.8)"
+    );
+
+    Ok(Json(record))
+}
+
+/// GET /api/v1/repos/:id/commits/:sha/signature
+///
+/// Return the Sigstore commit signature for a specific commit SHA, if one exists.
+pub async fn get_commit_signature(
+    State(state): State<Arc<AppState>>,
+    Path((repo_id, sha)): Path<(String, String)>,
+) -> Result<Json<CommitSignature>, ApiError> {
+    // Verify the repo exists.
+    let _ = repo_path(&state, &repo_id).await?;
+
+    let store = state.commit_signatures.lock().await;
+    store
+        .get(&sha)
+        .cloned()
+        .map(Json)
+        .ok_or_else(|| ApiError::NotFound(format!("no signature found for commit {sha}")))
 }
 
 /// POST /api/v1/repos/:id/jj/undo
@@ -269,9 +313,9 @@ mod tests {
         assert!(json["change_id"].as_str().is_some());
     }
 
-    /// jj squash returns 204.
+    /// jj squash returns 200 with a commit signature (M13.8 Sigstore).
     #[tokio::test]
-    async fn jj_squash_returns_no_content() {
+    async fn jj_squash_returns_commit_signature() {
         let app = app();
         let (app, repo_id) = create_project_and_repo(app).await;
 
@@ -286,7 +330,79 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert!(json["commit_sha"].as_str().is_some(), "missing commit_sha");
+        assert!(json["signature"].as_str().is_some(), "missing signature");
+        assert!(
+            json["signing_key_id"].as_str().is_some(),
+            "missing signing_key_id"
+        );
+        assert_eq!(json["algorithm"].as_str().unwrap(), "EdDSA");
+        assert_eq!(json["sigstore_mode"].as_str().unwrap(), "local");
+    }
+
+    /// jj squash signature can be retrieved via GET /commits/:sha/signature (M13.8).
+    #[tokio::test]
+    async fn commit_signature_retrievable_after_squash() {
+        use tower::ServiceExt as _;
+        let state = crate::mem::test_state();
+        let app = crate::build_router(state);
+        let (app, repo_id) = create_project_and_repo(app).await;
+
+        // First squash to produce a signature.
+        let squash_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/repos/{repo_id}/jj/squash"))
+                    .header("Authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(squash_resp.status(), StatusCode::OK);
+        let squash_json = body_json(squash_resp).await;
+        let sha = squash_json["commit_sha"].as_str().unwrap().to_string();
+
+        // Then retrieve the signature by SHA.
+        let sig_resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/repos/{repo_id}/commits/{sha}/signature"))
+                    .header("Authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(sig_resp.status(), StatusCode::OK);
+        let sig_json = body_json(sig_resp).await;
+        assert_eq!(sig_json["commit_sha"].as_str().unwrap(), sha);
+        assert!(sig_json["signature"].as_str().is_some());
+    }
+
+    /// GET /commits/:sha/signature returns 404 for an unknown SHA (M13.8).
+    #[tokio::test]
+    async fn commit_signature_unknown_sha_returns_404() {
+        let app = app();
+        let (app, repo_id) = create_project_and_repo(app).await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/v1/repos/{repo_id}/commits/deadbeef/signature"
+                    ))
+                    .header("Authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     /// jj undo returns 204.

--- a/crates/gyre-server/src/api/mod.rs
+++ b/crates/gyre-server/src/api/mod.rs
@@ -151,6 +151,10 @@ pub fn api_router() -> Router<Arc<AppState>> {
         .route("/api/v1/repos/:id/jj/squash", post(jj::jj_squash))
         .route("/api/v1/repos/:id/jj/undo", post(jj::jj_undo))
         .route("/api/v1/repos/:id/jj/bookmark", post(jj::jj_bookmark))
+        .route(
+            "/api/v1/repos/:id/commits/:sha/signature",
+            get(jj::get_commit_signature),
+        )
         // Agents
         .route(
             "/api/v1/agents",

--- a/crates/gyre-server/src/commit_signatures.rs
+++ b/crates/gyre-server/src/commit_signatures.rs
@@ -1,0 +1,103 @@
+//! Commit signature store for jj squash Sigstore signing (M13.8).
+//!
+//! After every `jj squash` the server signs the resulting commit SHA with the
+//! forge's Ed25519 key and stores a `CommitSignature` record here.
+//! The `GET /api/v1/repos/{id}/commits/{sha}/signature` endpoint returns the
+//! stored record so callers can verify the signature against the JWKS endpoint.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Signing algorithm in use.  Currently only Ed25519 via the forge's OIDC key.
+pub const ALGORITHM: &str = "EdDSA";
+
+/// Mode of Sigstore signing.  Embedded in each `CommitSignature` record so
+/// consumers know whether an external CA was involved.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SigstoreMode {
+    /// Signed locally with the forge's Ed25519 key — no external Fulcio/Rekor.
+    Local,
+    /// Would use an external Fulcio CA (not yet configured; records a warning).
+    Fulcio,
+}
+
+impl SigstoreMode {
+    /// Parse from `GYRE_SIGSTORE_MODE` env var (default: `"local"`).
+    pub fn from_env() -> Self {
+        match std::env::var("GYRE_SIGSTORE_MODE")
+            .unwrap_or_default()
+            .to_lowercase()
+            .as_str()
+        {
+            "fulcio" => {
+                tracing::warn!(
+                    "GYRE_SIGSTORE_MODE=fulcio: external Fulcio CA is not yet configured; \
+                     falling back to local signing"
+                );
+                Self::Fulcio
+            }
+            _ => Self::Local,
+        }
+    }
+}
+
+/// A signed record for one commit SHA produced by `jj squash`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitSignature {
+    /// The git commit SHA that was signed.
+    pub commit_sha: String,
+    /// Agent/user ID that triggered the squash (signer identity).
+    pub signer_id: String,
+    /// Signing algorithm (`"EdDSA"`).
+    pub algorithm: String,
+    /// Base64-encoded Ed25519 signature over the raw commit SHA bytes.
+    pub signature: String,
+    /// `kid` of the forge's Ed25519 key (matches `GET /.well-known/jwks.json`).
+    pub signing_key_id: String,
+    /// Unix epoch seconds when the signature was created.
+    pub signed_at: u64,
+    /// Mode used for signing.
+    pub sigstore_mode: SigstoreMode,
+}
+
+/// In-memory store: commit SHA → `CommitSignature`.
+pub type CommitSignatureStore = Arc<Mutex<HashMap<String, CommitSignature>>>;
+
+/// Sign `commit_sha` with the forge's Ed25519 key and return a `CommitSignature`.
+pub fn sign_commit(
+    commit_sha: &str,
+    signer_id: &str,
+    signing_key: &crate::auth::AgentSigningKey,
+    mode: SigstoreMode,
+) -> CommitSignature {
+    let raw_sig = signing_key.sign_bytes(commit_sha.as_bytes());
+    CommitSignature {
+        commit_sha: commit_sha.to_string(),
+        signer_id: signer_id.to_string(),
+        algorithm: ALGORITHM.to_string(),
+        signature: BASE64.encode(&raw_sig),
+        signing_key_id: signing_key.kid.clone(),
+        signed_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        sigstore_mode: mode,
+    }
+}
+
+/// Verify a `CommitSignature` using the provided raw 32-byte Ed25519 public key.
+///
+/// Returns `true` if the signature is valid.
+pub fn verify_commit_signature(record: &CommitSignature, public_key_bytes: &[u8]) -> bool {
+    use ring::signature::{self, UnparsedPublicKey};
+    let sig_bytes = match BASE64.decode(&record.signature) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let pk = UnparsedPublicKey::new(&signature::ED25519, public_key_bytes);
+    pk.verify(record.commit_sha.as_bytes(), &sig_bytes).is_ok()
+}

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod api;
 pub mod attestation;
 pub mod audit_simulator;
 pub(crate) mod auth;
+pub mod commit_signatures;
 pub mod domain_events;
 pub mod gate_executor;
 pub(crate) mod git_http;
@@ -179,6 +180,10 @@ pub struct AppState {
     pub trusted_issuers: Vec<String>,
     /// Cached JWKS from trusted remote Gyre instances: issuer URL -> entry (G11).
     pub remote_jwks_cache: Arc<tokio::sync::RwLock<HashMap<String, auth::RemoteJwksEntry>>>,
+    /// Commit signatures produced by jj squash (M13.8 Sigstore): commit_sha -> CommitSignature.
+    pub commit_signatures: commit_signatures::CommitSignatureStore,
+    /// Sigstore signing mode (local Ed25519 or Fulcio CA).  Set via `GYRE_SIGSTORE_MODE`.
+    pub sigstore_mode: commit_signatures::SigstoreMode,
 }
 
 /// Global authentication middleware for all `/api/v1/` routes.
@@ -496,6 +501,8 @@ pub fn build_state(
             })
             .unwrap_or_default(),
         remote_jwks_cache: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+        commit_signatures: Arc::new(Mutex::new(HashMap::new())),
+        sigstore_mode: commit_signatures::SigstoreMode::from_env(),
     })
 }
 

--- a/crates/gyre-server/src/mem.rs
+++ b/crates/gyre-server/src/mem.rs
@@ -134,8 +134,8 @@ impl JjOpsPort for NoopJjOps {
         Ok(vec![])
     }
 
-    async fn jj_squash(&self, _repo_path: &str) -> Result<()> {
-        Ok(())
+    async fn jj_squash(&self, _repo_path: &str) -> Result<String> {
+        Ok("0000000000000000000000000000000000000000".to_string())
     }
 
     async fn jj_bookmark_create(
@@ -1133,5 +1133,7 @@ pub fn test_state() -> Arc<crate::AppState> {
         attestation_store: Arc::new(Mutex::new(HashMap::new())),
         trusted_issuers: vec![],
         remote_jwks_cache: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+        commit_signatures: Arc::new(Mutex::new(HashMap::new())),
+        sigstore_mode: crate::commit_signatures::SigstoreMode::Local,
     })
 }

--- a/crates/gyre-server/src/middleware.rs
+++ b/crates/gyre-server/src/middleware.rs
@@ -159,6 +159,8 @@ mod tests {
             attestation_store: base.attestation_store.clone(),
             trusted_issuers: base.trusted_issuers.clone(),
             remote_jwks_cache: base.remote_jwks_cache.clone(),
+            commit_signatures: base.commit_signatures.clone(),
+            sigstore_mode: base.sigstore_mode.clone(),
         });
         crate::build_router(state)
     }


### PR DESCRIPTION
## Summary

Closes M13.8 (long-deferred) with a pragmatic local-signing approach using the forge's own Ed25519 key — no external Fulcio/Rekor dependency required.

- **`POST /api/v1/repos/{id}/jj/squash`** now returns `200 JSON` with a `CommitSignature` record (commit SHA, base64 Ed25519 signature, key ID, algorithm, mode, timestamp) instead of `204 No Content`
- **`GET /api/v1/repos/{id}/commits/{sha}/signature`** — new endpoint to look up and verify any signature previously produced by squash (404 if not found)
- **`GYRE_SIGSTORE_MODE`** env var: `local` (default, signs with forge Ed25519 key), `fulcio` (logs a warning — future hook for external Fulcio CA)
- `JjOpsPort::jj_squash` signature changed: returns `Result<String>` (commit SHA) instead of `Result<()>`
- New `commit_signatures` module: `CommitSignature`, `sign_commit()`, `verify_commit_signature()`, `SigstoreMode`
- Signatures stored in an in-memory `CommitSignatureStore` in AppState

## Test plan

- [x] `jj_squash_returns_commit_signature` — 200 with all required fields
- [x] `commit_signature_retrievable_after_squash` — GET returns the stored record
- [x] `commit_signature_unknown_sha_returns_404` — GET 404 for unknown SHA
- [x] All 415 existing server unit tests still pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)