### PR TITLE
feat(server): G6 ABAC — attribute-based access control using JWT claims

### DIFF
--- a/crates/gyre-server/src/abac.rs
+++ b/crates/gyre-server/src/abac.rs
@@ -1,0 +1,487 @@
+//! Attribute-Based Access Control (ABAC) for gyre-server (G6).
+//!
+//! Policies are defined per-repo and evaluated against the caller's JWT claims.
+//! A repo with no policies is unrestricted. A repo with policies requires the
+//! caller's JWT to satisfy AT LEAST ONE policy (OR logic across policies;
+//! AND logic across required_claims within a policy).
+//!
+//! Callers authenticated via the global admin token or API keys bypass ABAC
+//! (they carry no JWT claims).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{auth::AuthenticatedAgent, AppState};
+
+use super::api::error::ApiError;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A single ABAC policy. All `required_claims` must match (AND logic).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AbacPolicy {
+    /// Resource type this policy applies to (e.g. "repo", "task").
+    pub resource_type: String,
+    /// Optional specific resource ID. When set, policy only applies to that ID.
+    /// When absent, policy applies to all resources of the given `resource_type`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_id: Option<String>,
+    /// Claim key → required value. All must be present in the caller's JWT.
+    /// String claims: exact match. Array claims: the expected value must appear
+    /// in the array.
+    pub required_claims: HashMap<String, String>,
+}
+
+// ---------------------------------------------------------------------------
+// Policy evaluation
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if all `required_claims` in `policy` are satisfied by
+/// the provided JWT `claims` JSON value.
+pub fn evaluate_policy(policy: &AbacPolicy, claims: &serde_json::Value) -> bool {
+    for (key, expected) in &policy.required_claims {
+        match claims.get(key) {
+            Some(serde_json::Value::String(s)) => {
+                if s != expected {
+                    return false;
+                }
+            }
+            Some(serde_json::Value::Array(arr)) => {
+                if !arr.iter().any(|v| v.as_str() == Some(expected.as_str())) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Check ABAC policies for a repo. Returns `Ok(())` if access is granted,
+/// `Err(reason)` if denied.
+///
+/// - No policies configured → open access.
+/// - `auth.jwt_claims` is `None` (global token or API key) → bypass ABAC.
+/// - Otherwise: at least one policy must be satisfied.
+pub async fn check_repo_abac(
+    state: &AppState,
+    repo_id: &str,
+    auth: &AuthenticatedAgent,
+) -> Result<(), String> {
+    let policies_guard = state.abac_policies.lock().await;
+    let repo_policies = match policies_guard.get(repo_id) {
+        Some(p) if !p.is_empty() => p,
+        _ => return Ok(()), // No policies = unrestricted.
+    };
+
+    // Global token and API keys carry no JWT claims → admin bypass.
+    let claims = match &auth.jwt_claims {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    // Evaluate each policy; pass if any matches.
+    for policy in repo_policies {
+        if evaluate_policy(policy, claims) {
+            return Ok(());
+        }
+    }
+
+    Err(format!(
+        "ABAC denied: no policy satisfied for repo {repo_id}"
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handlers
+// ---------------------------------------------------------------------------
+
+/// Response body for GET/PUT abac-policy.
+#[derive(Serialize)]
+pub struct AbacPolicyResponse {
+    pub repo_id: String,
+    pub policies: Vec<AbacPolicy>,
+}
+
+/// GET /api/v1/repos/:id/abac-policy — list ABAC policies for a repo.
+pub async fn get_abac_policy(
+    State(state): State<Arc<AppState>>,
+    Path(repo_id): Path<String>,
+) -> Result<Json<AbacPolicyResponse>, ApiError> {
+    state
+        .repos
+        .find_by_id(&gyre_common::Id::new(&repo_id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("repo {repo_id} not found")))?;
+
+    let policies = state
+        .abac_policies
+        .lock()
+        .await
+        .get(&repo_id)
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(Json(AbacPolicyResponse { repo_id, policies }))
+}
+
+/// Request body for PUT abac-policy.
+#[derive(Deserialize)]
+pub struct SetAbacPoliciesRequest {
+    pub policies: Vec<AbacPolicy>,
+}
+
+/// PUT /api/v1/repos/:id/abac-policy — set ABAC policies (AdminOnly).
+pub async fn set_abac_policy(
+    State(state): State<Arc<AppState>>,
+    _admin: crate::auth::AdminOnly,
+    Path(repo_id): Path<String>,
+    Json(req): Json<SetAbacPoliciesRequest>,
+) -> Result<(StatusCode, Json<AbacPolicyResponse>), ApiError> {
+    state
+        .repos
+        .find_by_id(&gyre_common::Id::new(&repo_id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("repo {repo_id} not found")))?;
+
+    state
+        .abac_policies
+        .lock()
+        .await
+        .insert(repo_id.clone(), req.policies.clone());
+
+    Ok((
+        StatusCode::OK,
+        Json(AbacPolicyResponse {
+            repo_id,
+            policies: req.policies,
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mem::test_state;
+    use axum::{body::Body, Router};
+    use gyre_domain::Repository;
+    use http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    // --- evaluate_policy tests -----------------------------------------------
+
+    #[test]
+    fn policy_no_claims_required_always_passes() {
+        let policy = AbacPolicy {
+            resource_type: "repo".to_string(),
+            resource_id: None,
+            required_claims: HashMap::new(),
+        };
+        let claims = serde_json::json!({});
+        assert!(evaluate_policy(&policy, &claims));
+    }
+
+    #[test]
+    fn policy_string_claim_exact_match() {
+        let policy = AbacPolicy {
+            resource_type: "repo".to_string(),
+            resource_id: None,
+            required_claims: [("scope".to_string(), "repo:A".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let matching = serde_json::json!({ "scope": "repo:A" });
+        assert!(evaluate_policy(&policy, &matching));
+
+        let wrong = serde_json::json!({ "scope": "repo:B" });
+        assert!(!evaluate_policy(&policy, &wrong));
+
+        let missing = serde_json::json!({});
+        assert!(!evaluate_policy(&policy, &missing));
+    }
+
+    #[test]
+    fn policy_array_claim_contains_check() {
+        let policy = AbacPolicy {
+            resource_type: "repo".to_string(),
+            resource_id: None,
+            required_claims: [("groups".to_string(), "infra".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let has_group = serde_json::json!({ "groups": ["infra", "dev"] });
+        assert!(evaluate_policy(&policy, &has_group));
+
+        let missing_group = serde_json::json!({ "groups": ["dev"] });
+        assert!(!evaluate_policy(&policy, &missing_group));
+    }
+
+    #[test]
+    fn policy_multiple_required_claims_all_must_match() {
+        let policy = AbacPolicy {
+            resource_type: "repo".to_string(),
+            resource_id: None,
+            required_claims: [
+                ("scope".to_string(), "repo:A".to_string()),
+                ("department".to_string(), "engineering".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        };
+
+        let all_match = serde_json::json!({ "scope": "repo:A", "department": "engineering" });
+        assert!(evaluate_policy(&policy, &all_match));
+
+        let partial = serde_json::json!({ "scope": "repo:A" });
+        assert!(!evaluate_policy(&policy, &partial));
+    }
+
+    // --- check_repo_abac tests -----------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_policies_grants_access() {
+        let state = test_state();
+        let auth = AuthenticatedAgent {
+            agent_id: "agent-1".to_string(),
+            user_id: None,
+            roles: vec![],
+            tenant_id: "default".to_string(),
+            jwt_claims: Some(serde_json::json!({ "scope": "repo:X" })),
+        };
+        assert!(check_repo_abac(&state, "repo-1", &auth).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_jwt_claims_bypasses_abac() {
+        let state = test_state();
+        // Add a restrictive policy.
+        state.abac_policies.lock().await.insert(
+            "repo-1".to_string(),
+            vec![AbacPolicy {
+                resource_type: "repo".to_string(),
+                resource_id: None,
+                required_claims: [("scope".to_string(), "repo:X".to_string())]
+                    .into_iter()
+                    .collect(),
+            }],
+        );
+        // Global token / API key: jwt_claims is None → bypass.
+        let auth = AuthenticatedAgent {
+            agent_id: "system".to_string(),
+            user_id: None,
+            roles: vec![gyre_domain::UserRole::Admin],
+            tenant_id: "default".to_string(),
+            jwt_claims: None,
+        };
+        assert!(check_repo_abac(&state, "repo-1", &auth).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn matching_claim_grants_access() {
+        let state = test_state();
+        state.abac_policies.lock().await.insert(
+            "repo-A".to_string(),
+            vec![AbacPolicy {
+                resource_type: "repo".to_string(),
+                resource_id: None,
+                required_claims: [("scope".to_string(), "repo:A".to_string())]
+                    .into_iter()
+                    .collect(),
+            }],
+        );
+        let auth = AuthenticatedAgent {
+            agent_id: "agent-1".to_string(),
+            user_id: None,
+            roles: vec![],
+            tenant_id: "default".to_string(),
+            jwt_claims: Some(serde_json::json!({ "scope": "repo:A" })),
+        };
+        assert!(check_repo_abac(&state, "repo-A", &auth).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mismatching_claim_denies_access() {
+        let state = test_state();
+        state.abac_policies.lock().await.insert(
+            "repo-B".to_string(),
+            vec![AbacPolicy {
+                resource_type: "repo".to_string(),
+                resource_id: None,
+                required_claims: [("scope".to_string(), "repo:B".to_string())]
+                    .into_iter()
+                    .collect(),
+            }],
+        );
+        // Agent only has scope for repo:A, not repo:B
+        let auth = AuthenticatedAgent {
+            agent_id: "agent-1".to_string(),
+            user_id: None,
+            roles: vec![],
+            tenant_id: "default".to_string(),
+            jwt_claims: Some(serde_json::json!({ "scope": "repo:A" })),
+        };
+        assert!(check_repo_abac(&state, "repo-B", &auth).await.is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn agent_with_scope_a_can_access_repo_a_but_not_repo_b() {
+        let state = test_state();
+        // Set up policies for both repos.
+        {
+            let mut policies = state.abac_policies.lock().await;
+            policies.insert(
+                "repo-A".to_string(),
+                vec![AbacPolicy {
+                    resource_type: "repo".to_string(),
+                    resource_id: None,
+                    required_claims: [("scope".to_string(), "repo:A".to_string())]
+                        .into_iter()
+                        .collect(),
+                }],
+            );
+            policies.insert(
+                "repo-B".to_string(),
+                vec![AbacPolicy {
+                    resource_type: "repo".to_string(),
+                    resource_id: None,
+                    required_claims: [("scope".to_string(), "repo:B".to_string())]
+                        .into_iter()
+                        .collect(),
+                }],
+            );
+        }
+        let auth = AuthenticatedAgent {
+            agent_id: "agent-1".to_string(),
+            user_id: None,
+            roles: vec![],
+            tenant_id: "default".to_string(),
+            jwt_claims: Some(serde_json::json!({ "scope": "repo:A" })),
+        };
+        assert!(check_repo_abac(&state, "repo-A", &auth).await.is_ok());
+        assert!(check_repo_abac(&state, "repo-B", &auth).await.is_err());
+    }
+
+    // --- HTTP handler tests --------------------------------------------------
+
+    fn app_with_repo() -> (Router, std::sync::Arc<crate::AppState>) {
+        let state = test_state();
+        let repo = Repository::new(
+            gyre_common::Id::new("repo-1"),
+            gyre_common::Id::new("proj-1"),
+            "test-repo",
+            "/tmp/test-repo",
+            0,
+        );
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(state.repos.create(&repo))
+                .unwrap();
+        });
+        let app = crate::api::api_router().with_state(state.clone());
+        (app, state)
+    }
+
+    async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_abac_policy_returns_empty_by_default() {
+        let (app, _state) = app_with_repo();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/repos/repo-1/abac-policy")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["repo_id"], "repo-1");
+        assert_eq!(json["policies"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_and_get_abac_policy_round_trips() {
+        let (app, _state) = app_with_repo();
+        let body = serde_json::json!({
+            "policies": [{
+                "resource_type": "repo",
+                "required_claims": { "scope": "repo:1" }
+            }]
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/repos/repo-1/abac-policy")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["policies"].as_array().unwrap().len(), 1);
+        assert_eq!(json["policies"][0]["required_claims"]["scope"], "repo:1");
+
+        // GET returns persisted value.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/repos/repo-1/abac-policy")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp).await;
+        assert_eq!(json["policies"][0]["required_claims"]["scope"], "repo:1");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn set_abac_policy_unknown_repo_returns_404() {
+        let state = test_state();
+        let app = crate::api::api_router().with_state(state);
+        let body = serde_json::json!({ "policies": [] });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/repos/no-such/abac-policy")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/gyre-server/src/api/mod.rs
+++ b/crates/gyre-server/src/api/mod.rs
@@ -125,6 +125,11 @@ pub fn api_router() -> Router<Arc<AppState>> {
             "/api/v1/repos/:id/spec-policy",
             get(spec_policy::get_spec_policy).put(spec_policy::set_spec_policy),
         )
+        // ABAC policies (G6)
+        .route(
+            "/api/v1/repos/:id/abac-policy",
+            get(crate::abac::get_abac_policy).put(crate::abac::set_abac_policy),
+        )
         // Cross-agent code awareness (M13.4)
         .route("/api/v1/repos/:id/blame", get(code_awareness::get_blame))
         .route(

--- a/crates/gyre-server/src/api/spawn.rs
+++ b/crates/gyre-server/src/api/spawn.rs
@@ -71,6 +71,11 @@ pub async fn spawn_agent(
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("repo {} not found", req.repo_id)))?;
 
+    // G6: ABAC enforcement — check repo access policies against the caller's JWT claims.
+    crate::abac::check_repo_abac(&state, &req.repo_id, &auth)
+        .await
+        .map_err(ApiError::Forbidden)?;
+
     // Verify task exists
     let mut task = state
         .tasks

--- a/crates/gyre-server/src/auth.rs
+++ b/crates/gyre-server/src/auth.rs
@@ -194,6 +194,10 @@ pub struct AuthenticatedAgent {
     /// - JWT auth: extracted from `tenant_id` claim (defaults to "default").
     /// - All other auth methods: always "default".
     pub tenant_id: String,
+    /// Raw JWT claims for ABAC evaluation (G6).
+    /// - JWT auth (Keycloak or agent JWT): populated with the full claims object.
+    /// - Global token or API key: `None` — ABAC checks are bypassed for these.
+    pub jwt_claims: Option<serde_json::Value>,
 }
 
 // -- JWT claim types ----------------------------------------------------------
@@ -356,6 +360,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedAgent {
                 user_id: None,
                 roles: vec![UserRole::Admin],
                 tenant_id: "default".to_string(),
+                jwt_claims: None, // Admin bypass — no ABAC evaluation.
             });
         }
 
@@ -368,18 +373,27 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedAgent {
                 .map(|(id, _)| id.clone())
             {
                 // JWT tokens: additionally validate signature and expiry.
-                if token.starts_with("ey") {
-                    if let Err(e) = state.agent_signing_key.validate(token, &state.base_url) {
-                        tracing::debug!("Agent JWT validation failed: {e}");
-                        return Err((StatusCode::UNAUTHORIZED, "Invalid or expired agent token")
-                            .into_response());
+                let jwt_claims = if token.starts_with("ey") {
+                    match state.agent_signing_key.validate(token, &state.base_url) {
+                        Ok(agent_claims) => serde_json::to_value(&agent_claims).ok(),
+                        Err(e) => {
+                            tracing::debug!("Agent JWT validation failed: {e}");
+                            return Err((
+                                StatusCode::UNAUTHORIZED,
+                                "Invalid or expired agent token",
+                            )
+                                .into_response());
+                        }
                     }
-                }
+                } else {
+                    None // Legacy UUID token — no JWT claims for ABAC.
+                };
                 return Ok(AuthenticatedAgent {
                     agent_id,
                     user_id: None,
                     roles: vec![UserRole::Agent],
                     tenant_id: "default".to_string(),
+                    jwt_claims,
                 });
             }
         }
@@ -411,6 +425,7 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedAgent {
                     user_id: Some(user.id),
                     roles: user.roles,
                     tenant_id: "default".to_string(),
+                    jwt_claims: None, // API key — no ABAC evaluation.
                 });
             }
         }
@@ -491,6 +506,11 @@ async fn validate_jwt(
     let token_data = jsonwebtoken::decode::<JwtClaims>(token, &decoding_key, &validation)
         .map_err(|e| format!("decode: {e}"))?;
 
+    // Also capture the raw claims as JSON for ABAC evaluation (G6).
+    let raw_claims = jsonwebtoken::decode::<serde_json::Value>(token, &decoding_key, &validation)
+        .map(|td| td.claims)
+        .ok();
+
     let claims = token_data.claims;
     let roles = roles_from_claims(&claims);
     let username = claims
@@ -518,6 +538,7 @@ async fn validate_jwt(
         user_id: Some(user.id),
         roles: user.roles,
         tenant_id,
+        jwt_claims: raw_claims,
     })
 }
 
@@ -720,11 +741,13 @@ async fn validate_federated_jwt(token: &str, state: &Arc<AppState>) -> Option<Au
     let remote_host = normalized_iss
         .trim_start_matches("https://")
         .trim_start_matches("http://");
+    let fed_claims_json = serde_json::to_value(&claims).ok();
     Some(AuthenticatedAgent {
         agent_id: format!("{remote_host}/{}", claims.sub),
         user_id: None,
         roles: vec![UserRole::Agent],
         tenant_id: "default".to_string(),
+        jwt_claims: fed_claims_json,
     })
 }
 

--- a/crates/gyre-server/src/git_http.rs
+++ b/crates/gyre-server/src/git_http.rs
@@ -231,6 +231,11 @@ pub async fn git_receive_pack(
     let repo_path = resolved.path;
     let default_branch = resolved.default_branch;
 
+    // G6: ABAC enforcement — check repo access policies against the caller's JWT claims.
+    if let Err(reason) = crate::abac::check_repo_abac(&state, &repo_id, &auth).await {
+        return (StatusCode::FORBIDDEN, reason).into_response();
+    }
+
     // M13.2: Extract model context header before consuming the request body.
     let model_context = req
         .headers()

--- a/crates/gyre-server/src/lib.rs
+++ b/crates/gyre-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod abac;
 pub(crate) mod activity;
 pub mod api;
 pub mod attestation;
@@ -184,6 +185,8 @@ pub struct AppState {
     pub commit_signatures: commit_signatures::CommitSignatureStore,
     /// Sigstore signing mode (local Ed25519 or Fulcio CA).  Set via `GYRE_SIGSTORE_MODE`.
     pub sigstore_mode: commit_signatures::SigstoreMode,
+    /// Per-repo ABAC policies: repo_id -> list of AbacPolicy (G6).
+    pub abac_policies: Arc<Mutex<HashMap<String, Vec<abac::AbacPolicy>>>>,
 }
 
 /// Global authentication middleware for all `/api/v1/` routes.
@@ -503,6 +506,7 @@ pub fn build_state(
         remote_jwks_cache: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
         commit_signatures: Arc::new(Mutex::new(HashMap::new())),
         sigstore_mode: commit_signatures::SigstoreMode::from_env(),
+        abac_policies: Arc::new(Mutex::new(HashMap::new())),
     })
 }
 

--- a/crates/gyre-server/src/mem.rs
+++ b/crates/gyre-server/src/mem.rs
@@ -1135,5 +1135,6 @@ pub fn test_state() -> Arc<crate::AppState> {
         remote_jwks_cache: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
         commit_signatures: Arc::new(Mutex::new(HashMap::new())),
         sigstore_mode: crate::commit_signatures::SigstoreMode::Local,
+        abac_policies: Arc::new(Mutex::new(HashMap::new())),
     })
 }

--- a/crates/gyre-server/src/middleware.rs
+++ b/crates/gyre-server/src/middleware.rs
@@ -161,6 +161,7 @@ mod tests {
             remote_jwks_cache: base.remote_jwks_cache.clone(),
             commit_signatures: base.commit_signatures.clone(),
             sigstore_mode: base.sigstore_mode.clone(),
+            abac_policies: base.abac_policies.clone(),
         });
         crate::build_router(state)
     }


### PR DESCRIPTION
## Summary

- Implements ABAC (Attribute-Based Access Control) per-repo using JWT claims (G6)
- `AbacPolicy` struct: `resource_type`, `resource_id`, `required_claims: HashMap<String, String>`
- `GET/PUT /api/v1/repos/:id/abac-policy` — list/set policies (PUT requires Admin)
- ABAC enforced on git push (`git-receive-pack`) and agent spawn
- Adds `jwt_claims: Option<serde_json::Value>` to `AuthenticatedAgent` for claim evaluation
- Global token and API keys bypass ABAC (admin-level access)

## Policy Semantics

- No policies on a repo → unrestricted access
- With policies → caller JWT must satisfy **at least one** policy (OR across policies)
- Within a policy → **all** `required_claims` must match (AND logic)
- String claims: exact match; Array claims: element contains check
- Agent JWTs get `{ "sub", "scope": "agent", "task_id", "spawned_by", ... }`
- Keycloak JWTs get full token claims (`preferred_username`, `email`, `realm_access.roles`, custom claims)

## Test plan

- [x] 12 unit tests in `abac.rs`: policy evaluation logic, check_repo_abac, HTTP handlers
- [x] Key scenario: `agent_with_scope_a_can_access_repo_a_but_not_repo_b`
- [x] All 538 existing tests pass (no regressions)
- [x] Clippy clean

Closes TASK-131

🤖 Generated with [Claude Code](https://claude.com/claude-code)