### PR TITLE
test(server): add Authorization headers to create_worktree tests (#197 followup)

### DIFF
--- a/crates/gyre-server/src/api/agent_tracking.rs
+++ b/crates/gyre-server/src/api/agent_tracking.rs
@@ -374,6 +374,7 @@ mod tests {
                     .method("POST")
                     .uri(format!("/api/v1/repos/{repo_id}/worktrees"))
                     .header("content-type", "application/json")
+                    .header("Authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )
@@ -428,6 +429,7 @@ mod tests {
                     .method("POST")
                     .uri(format!("/api/v1/repos/{repo_id}/worktrees"))
                     .header("content-type", "application/json")
+                    .header("Authorization", "Bearer test-token")
                     .body(Body::from(serde_json::to_vec(&body).unwrap()))
                     .unwrap(),
             )


### PR DESCRIPTION
## Summary

PR #197 added `AuthenticatedAgent` to `create_worktree` but the two existing unit tests sent no `Authorization` header, causing them to receive 401 instead of 201 — breaking CI on main.

My test fix was prepared during review of #197 but was pushed to the feature branch after the PR had already merged, so it never landed.

**Fix:** Add `Authorization: Bearer test-token` to both `POST /api/v1/repos/{id}/worktrees` test requests to match the `test_state()` global auth token.

## Test plan
- [x] `cargo test -p gyre-server --lib create_and_list_worktrees` — passes
- [x] `cargo test -p gyre-server --lib create_worktree_with_task_id` — passes
- [x] Pre-commit hooks pass

Fixes CI on main, unblocks PR #198 (docs).