### PR TITLE
docs: add missing M16 and M18 milestone spec files

### DIFF
--- a/specs/milestones/m16-security-hardening.md
+++ b/specs/milestones/m16-security-hardening.md
@@ -1,0 +1,48 @@
+# M16 — Security Hardening
+
+## Goal
+
+Close outstanding CISO findings and harden the server against injection, privilege escalation, and information-disclosure vulnerabilities identified in earlier milestones.
+
+## Deliverables
+
+### M16.1 — Release Automation Endpoint
+
+`POST /api/v1/release/prepare` (Admin only):
+
+- Computes the next semver version from conventional commit history since the last tag
+- Generates a changelog with per-commit agent and task attribution
+- Optionally opens a release MR (`create_mr: true`, `mr_title: "..."`)
+- Request: `{repo_id, branch?, from?, create_mr?, mr_title?}`
+- Response: `{next_version, changelog, commit_count, mr?}`
+
+### M16-A — Git Argument Injection Prevention (release endpoint)
+
+The `branch` and `from` parameters on `POST /api/v1/release/prepare` are validated server-side before being passed to git:
+
+- Must not start with `-` (prevents flag injection, e.g. `--exec`)
+- Must not contain `..` (prevents range expansion attacks)
+
+Returns `400 Bad Request` if either validation fails. See also: M-8 (SHA hex validation on push).
+
+### M16.2 — Security Finding Resolutions
+
+All Critical, High, and Medium CISO findings identified through M15 were resolved:
+
+| Severity | Finding | Resolution |
+|---|---|---|
+| Medium | M15.3-A JWT role sync | JWT `realm_access.roles` claim now the authoritative role source |
+| Low | M12.3-B AgentReview stub | Documented as intentional stub; Low accepted risk |
+
+No Critical or High findings outstanding as of M16.
+
+## Security Posture at M16
+
+- 0 Critical, 0 High, 1 Medium (M15.3-A — JWT role sync, tracked), 1 Low (M12.3-B — AgentReview stub, accepted)
+- Global auth middleware enforced on all `/api/v1/` endpoints
+- Diesel ORM eliminates SQL injection class at adapter layer
+- SHA hex validation prevents git argument injection on push (`/git/.../git-receive-pack`)
+- HTTPS-only mirror URLs prevent SSRF via `POST /api/v1/repos/mirror`
+- AdminOnly on gate creation and push-gate configuration
+- Server-side repo path computation (no user-supplied paths)
+- `mirror_url` credential redaction in all API responses

--- a/specs/milestones/m18-agent-identity.md
+++ b/specs/milestones/m18-agent-identity.md
@@ -1,0 +1,77 @@
+# M18 — Agent Identity
+
+## Goal
+
+Give every agent a cryptographically verifiable identity: EdDSA JWT tokens issued by the forge's built-in OIDC provider, verifiable by any external party without a shared secret.
+
+## Deliverables
+
+### M18.1 — OIDC Provider
+
+The server acts as a minimal OIDC identity provider for its own agents.
+
+| Endpoint | Description |
+|---|---|
+| `GET /.well-known/openid-configuration` | OIDC discovery document — issuer URL, JWKS URI, supported algorithms. No auth required. |
+| `GET /.well-known/jwks.json` | Ed25519 JWK Set. No auth required. Rotate the key by restarting with a new `GYRE_SIGNING_KEY` (or let the server generate one). |
+
+### M18.2 — EdDSA JWT Agent Tokens
+
+`POST /api/v1/agents/spawn` now returns a signed JWT (`token` field) instead of a UUID token:
+
+- Algorithm: `EdDSA` (Ed25519)
+- Claims: `sub` (agent_id), `task_id`, `spawned_by`, `exp` (Unix expiry)
+- Starts with `ey` — three dot-separated base64url parts
+- Verify offline using the public key from `/.well-known/jwks.json`
+- TTL configured via `GYRE_AGENT_JWT_TTL` (default: `3600` seconds)
+- Legacy UUID tokens (from `POST /api/v1/agents`) are still accepted for backwards compatibility
+
+### M18.3 — Token Introspection
+
+`GET /api/v1/auth/token-info` — returns the decoded identity of the caller's token:
+
+```json
+{
+  "kind": "agent_jwt",          // agent_jwt | uuid_token | api_key | global
+  "agent_id": "...",
+  "task_id": "...",
+  "spawned_by": "...",
+  "exp": 1234567890
+}
+```
+
+### M18.4 — JWT Revocation on Complete
+
+When `POST /api/v1/agents/{id}/complete` succeeds, the agent's JWT is revoked in the database. Subsequent API calls with the same token return `401`. Agents must not reuse a token after completing. (See also M13.7.)
+
+### M18.5 — Spec Policy: Stale Spec Detection
+
+Per-repo spec enforcement policy (`GET/PUT /api/v1/repos/{id}/spec-policy`) gained two new fields:
+
+| Field | Default | Behaviour |
+|---|---|---|
+| `warn_stale_spec` | `false` | Emits `StaleSpecWarning` domain event when an MR's `spec_ref` SHA differs from the current HEAD of the spec file |
+| `require_current_spec` | `false` | Blocks the merge queue when the bound spec is stale (requires updated `spec_ref` before merge) |
+
+`StaleSpecWarning` is broadcast over WebSocket to all connected clients when triggered.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `GYRE_AGENT_JWT_TTL` | `3600` | Lifetime in seconds for EdDSA JWT agent tokens. After expiry, token is rejected even if not explicitly revoked. |
+
+## Test Suite
+
+`crates/gyre-server/tests/m18_oidc_integration.rs` — 8 integration tests:
+
+| Test | Coverage |
+|---|---|
+| OIDC discovery document shape | `/.well-known/openid-configuration` response fields |
+| JWKS JWK format | Ed25519 JWK in `/.well-known/jwks.json` |
+| JWT spawn token | `POST /agents/spawn` returns `ey...` JWT |
+| JWT auth | Spawned JWT accepted on authenticated endpoints |
+| Token-info claims | `GET /auth/token-info` returns correct kind + claims |
+| JWT revocation after complete | Token rejected after `POST /agents/{id}/complete` |
+| Expired JWT rejected | Token with past `exp` returns 401 |
+| UUID token still accepted | Legacy tokens from `POST /api/v1/agents` remain valid |


### PR DESCRIPTION
## Summary

Found during a routine idle-cycle audit: CLAUDE.md's **Architecture Decisions** table linked two milestone spec files that did not exist in the repo — broken links for any agent following the reference:

- `specs/milestones/m16-security-hardening.md` — **missing**
- `specs/milestones/m18-agent-identity.md` — **missing**

All M0–M15 and M17 specs existed; M16 and M18 were never committed.

This PR adds both files based on documented implementation details in CLAUDE.md and the merged PRs:

**m16-security-hardening.md:**
- `POST /api/v1/release/prepare` endpoint overview
- M16-A git argument injection prevention (branch/from validation)
- CISO finding resolution table
- Security posture summary at M16

**m18-agent-identity.md:**
- OIDC provider endpoints (`/.well-known/openid-configuration`, `/.well-known/jwks.json`)
- EdDSA JWT agent token format, claims, TTL
- `GET /api/v1/auth/token-info` introspection
- JWT revocation on agent complete
- Stale spec detection policy fields (`warn_stale_spec`, `require_current_spec`)
- `GYRE_AGENT_JWT_TTL` env var
- m18_oidc_integration.rs test coverage summary

## Test plan
- [x] Both files exist at referenced paths
- [x] `git ls-tree` confirms files present
- [x] Pre-commit hooks pass