### PR TITLE
docs: document G10 workload attestation + G12 SSH tunnel endpoints (#207 #208)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `POST/GET` | `/api/v1/agents` | Register (returns auth_token) / list (`?status=`) |
 | `GET` | `/api/v1/agents/{id}` | Get agent |
 | `PUT` | `/api/v1/agents/{id}/status` | Update agent status |
-| `PUT` | `/api/v1/agents/{id}/heartbeat` | Agent heartbeat |
+| `PUT` | `/api/v1/agents/{id}/heartbeat` | Agent heartbeat; on Linux, verifies PID liveness via `/proc/{pid}` and logs a warning if the process is no longer running (G10) |
 | `POST/GET` | `/api/v1/agents/{id}/messages` | Send/poll agent messages |
 | `POST` | `/api/v1/agents/{id}/logs` | Append a log line to the agent's log buffer (M11.2) |
 | `GET` | `/api/v1/agents/{id}/logs` | Paginated agent log lines (`?limit=100&offset=0`) (M11.2) |
@@ -168,6 +168,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/agents/{id}/touched-paths` | All repo branches and file paths written to by this agent (M13.4) |
 | `POST` | `/api/v1/agents/{id}/stack` | Agent self-reports its runtime stack fingerprint at spawn (M14.1) |
 | `GET` | `/api/v1/agents/{id}/stack` | Query agent's registered stack fingerprint (M14.1) |
+| `GET` | `/api/v1/agents/{id}/workload` | Current workload attestation — `{pid, hostname, compute_target, stack_hash, alive}`: captured at spawn; `alive` re-checked via `/proc/{pid}` on Linux (G10) |
 | `GET` | `/ws/agents/{id}/tty` | WebSocket TTY attach — auth via first-message Bearer token; replays buffered logs then streams live PTY output (M11.2) |
 | `POST/GET` | `/api/v1/tasks` | Create / list (`?status=&assigned_to=&parent_task_id=`) |
 | `GET/PUT` | `/api/v1/tasks/{id}` | Read / update task |
@@ -241,6 +242,9 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `PUT/DELETE` | `/api/v1/admin/siem/{id}` | Update / delete a SIEM target (Admin only) |
 | `POST/GET` | `/api/v1/admin/compute-targets` | Create / list remote compute targets (Admin only) |
 | `GET/DELETE` | `/api/v1/admin/compute-targets/{id}` | Get / delete a compute target (Admin only) |
+| `POST` | `/api/v1/admin/compute-targets/{id}/tunnel` | Open an SSH tunnel for a compute target: `{kind: "forward"\|"reverse", local_port, remote_port}`. Reverse tunnels (`-R`) let air-gapped agents dial out so the server can reach them through NAT. (G12, Admin only) |
+| `GET` | `/api/v1/admin/compute-targets/{id}/tunnel` | List active SSH tunnels for a compute target (G12, Admin only) |
+| `DELETE` | `/api/v1/admin/compute-targets/{id}/tunnel/{tid}` | Close an SSH tunnel — sends SIGTERM to the `ssh -N` process (G12, Admin only) |
 | `POST` | `/api/v1/admin/seed` | Idempotent demo data seed: 2 projects, 3 repos, 4 agents, 6 tasks, 2 MRs, 1 queue entry, 5 activity events. Returns `{already_seeded:true}` on repeat. AdminOnly. (M9.1) |
 | `POST` | `/api/v1/release/prepare` | Admin: compute next semver version from conventional commits + generate changelog with agent/task attribution; optionally open a release MR. Request: `{repo_id, branch?, from?, create_mr?, mr_title?}`; `branch` and `from` validated against git argument injection — must not start with `-` or contain `..` (M16-A). Response: `{next_version, changelog, commit_count, mr?}` (M16) |
 | `POST/GET` | `/api/v1/audit/events` | Record / query eBPF audit events (`?agent_id=&event_type=&since=`) |
@@ -478,7 +482,7 @@ Agents are created in dependency order (parents before children). Parent links a
     "spawned_by": "<caller-agent-id or user-id>",   // M13.2: who initiated spawn
     ...
   },
-  "token": "<signed-EdDSA-JWT>",   // M18: starts with "ey", 3 dot-separated parts; claims: sub=agent_id, task_id, spawned_by, exp. Verify via /.well-known/jwks.json. Legacy UUID tokens still accepted from POST /api/v1/agents.
+  "token": "<signed-EdDSA-JWT>",   // M18: starts with "ey", 3 dot-separated parts; claims: sub=agent_id, task_id, spawned_by, exp. G10: when spawned on a real process, also embeds wl_pid, wl_hostname, wl_compute_target, wl_stack_hash. Verify via /.well-known/jwks.json. Legacy UUID tokens still accepted from POST /api/v1/agents.
   "worktree_path": "/path/to/worktree",
   "clone_url": "http://localhost:3000/git/project/repo.git",
   "branch": "feat/my-feature",


### PR DESCRIPTION
## Summary

Two new feature PRs landed with documentation gaps in CLAUDE.md.

### PR #207 (G10 — local workload attestation)

Three gaps:
1. **Missing endpoint** `GET /api/v1/agents/{id}/workload` — returns current `WorkloadAttestation` (pid, hostname, compute_target, stack_hash, alive); added to endpoint table
2. **Heartbeat updated** — `PUT /api/v1/agents/{id}/heartbeat` now verifies PID liveness via `/proc/{pid}` on Linux; endpoint description updated
3. **JWT workload claims** — spawn response token comment updated to include `wl_pid`, `wl_hostname`, `wl_compute_target`, `wl_stack_hash` fields embedded when spawned on a real process

### PR #208 (G12 — SSH compute target + reverse tunnels)

Three new endpoints entirely absent from the endpoint table:
- `POST /api/v1/admin/compute-targets/{id}/tunnel` — open forward or reverse SSH tunnel
- `GET /api/v1/admin/compute-targets/{id}/tunnel` — list active tunnels for target
- `DELETE /api/v1/admin/compute-targets/{id}/tunnel/{tid}` — close tunnel (SIGTERM to `ssh -N`)

Includes explanatory note on reverse tunnels as the key NAT-traversal primitive for air-gapped agents.

## Test plan

- [x] No Rust changes — pre-commit hooks pass
- [x] All 4 edits verified against PR source diffs
- [x] CLAUDE.md endpoint table structure intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)