### PR TITLE
docs: document G8-A/B/C container security defaults (closes #210 gap)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET/PUT` | `/api/v1/admin/retention` | List / update retention policies (Admin only) |
 | `POST/GET` | `/api/v1/admin/siem` | Create / list SIEM forwarding targets (Admin only) |
 | `PUT/DELETE` | `/api/v1/admin/siem/{id}` | Update / delete a SIEM target (Admin only) |
-| `POST/GET` | `/api/v1/admin/compute-targets` | Create / list remote compute targets (`target_type`: `"local"`, `"ssh"`, `"container"` — Docker/Podman, auto-detected via `which`) (Admin only) |
+| `POST/GET` | `/api/v1/admin/compute-targets` | Create / list remote compute targets (`target_type`: `"local"`, `"ssh"`, `"container"` — Docker/Podman, auto-detected via `which`). **Container security defaults (G8):** `--network=none` (no outbound network — opt in via `network` field), `--memory=2g --pids-limit=512` (resource limits — override via `memory_limit`/`pids_limit`), `--user=65534:65534` (nobody:nogroup — override via `user`). (Admin only) |
 | `GET/DELETE` | `/api/v1/admin/compute-targets/{id}` | Get / delete a compute target (Admin only) |
 | `POST` | `/api/v1/admin/seed` | Idempotent demo data seed: 2 projects, 3 repos, 4 agents, 6 tasks, 2 MRs, 1 queue entry, 5 activity events. Returns `{already_seeded:true}` on repeat. AdminOnly. (M9.1) |
 | `POST` | `/api/v1/release/prepare` | Admin: compute next semver version from conventional commits + generate changelog with agent/task attribution; optionally open a release MR. Request: `{repo_id, branch?, from?, create_mr?, mr_title?}`; `branch` and `from` validated against git argument injection — must not start with `-` or contain `..` (M16-A). Response: `{next_version, changelog, commit_count, mr?}` (M16) |


### PR DESCRIPTION
## Summary

Documents the three container security defaults introduced by PR #210 in `CLAUDE.md`'s compute-targets endpoint entry.

- **G8-A** (`--network=none`): Agent containers have no outbound network access by default — operators opt in via the `network` field
- **G8-B** (`--memory=2g --pids-limit=512`): Resource limits enforced by default — override via `memory_limit` / `pids_limit` fields
- **G8-C** (`--user=65534:65534`): Containers run as nobody:nogroup (non-root) by default — override via `user` field

Companion docs PR to #210 (feature) and #209 (G10/G12 docs).

## Test plan

- [x] CLAUDE.md diff reviewed — single endpoint row updated with accurate field names from the `ContainerTarget` builder API
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)