### PR TITLE
docs: fix G12 tunnel request body — direction (not kind) + optional host fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `PUT/DELETE` | `/api/v1/admin/siem/{id}` | Update / delete a SIEM target (Admin only) |
 | `POST/GET` | `/api/v1/admin/compute-targets` | Create / list remote compute targets (`target_type`: `"local"`, `"ssh"`, `"container"` — Docker/Podman, auto-detected via `which`) (Admin only) |
 | `GET/DELETE` | `/api/v1/admin/compute-targets/{id}` | Get / delete a compute target (Admin only) |
-| `POST` | `/api/v1/admin/compute-targets/{id}/tunnel` | Open an SSH tunnel for a compute target: `{kind: "forward"\|"reverse", local_port, remote_port}`. Reverse tunnels (`-R`) let air-gapped agents dial out so the server can reach them through NAT. (G12, Admin only) |
+| `POST` | `/api/v1/admin/compute-targets/{id}/tunnel` | Open an SSH tunnel for a compute target: `{direction: "forward"|"reverse", local_port, remote_port, local_host?, remote_host?}` (`local_host` and `remote_host` default to `"localhost"`). Reverse tunnels (`-R`) let air-gapped agents dial out so the server can reach them through NAT. (G12, Admin only) |
 | `GET` | `/api/v1/admin/compute-targets/{id}/tunnel` | List active SSH tunnels for a compute target (G12, Admin only) |
 | `DELETE` | `/api/v1/admin/compute-targets/{id}/tunnel/{tid}` | Close an SSH tunnel — sends SIGTERM to the `ssh -N` process (G12, Admin only) |
 | `POST` | `/api/v1/admin/seed` | Idempotent demo data seed: 2 projects, 3 repos, 4 agents, 6 tasks, 2 MRs, 1 queue entry, 5 activity events. Returns `{already_seeded:true}` on repeat. AdminOnly. (M9.1) |


### PR DESCRIPTION
## Summary

Corrects the CLAUDE.md tunnel endpoint documentation introduced by PR #209.

**Bug:** `POST /api/v1/admin/compute-targets/{id}/tunnel` was documented with a `kind` field, but the actual `OpenTunnelRequest` struct uses `direction`.

**Missing fields:** `local_host` and `remote_host` (both optional, default to `"localhost"`) were not documented. These are required for forward tunnels pointing to non-localhost services.

**Before:**
```
{kind: "forward"|"reverse", local_port, remote_port}
```

**After:**
```
{direction: "forward"|"reverse", local_port, remote_port, local_host?, remote_host?}
```

Companion to PR #208 (G12 SSH feature) — fixes the docs gap before #208 merges.

## Test plan

- [x] Field name verified against `OpenTunnelRequest` struct in `crates/gyre-server/src/api/compute.rs`
- [x] Optional fields verified via test bodies in PR #208 diff
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)