### PR TITLE
Add approval modes and stack-bound agent identity to spec registry

### DIFF
--- a/specs/system/identity-security.md
+++ b/specs/system/identity-security.md
@@ -22,9 +22,16 @@ Three layers, each proving something different. All use existing protocols - no 
     "task_id": "TASK-007",
     "spawned_by": "user:jsell",
     "scope": ["repo:gyre:write", "mr:create"],
+    "stack_hash": "sha256:abc123def456...",
+    "persona": "security",
+    "attestation_level": 3,
     "exp": 1711036800
   }
   ```
+- **Stack hash as an OIDC claim.** The agent's stack fingerprint (from `supply-chain.md`) is embedded in the JWT. Any system verifying the token can check not just who the agent is, but what configuration it was running. This is used by:
+  - **Spec registry** (`spec-registry.md`): verify agent approvals came from the required stack
+  - **Agent gates** (`agent-gates.md`): verify gate agents match the policy's stack requirements
+  - **Merge attestation** (`agent-gates.md`): record which stack produced each gate result
 - Tokens are **short-lived and scoped to a task** - no long-lived API keys, no static secrets.
 - External systems verify agent identity by trusting Gyre's OIDC issuer (`/.well-known/openid-configuration`).
 - This is the same pattern GitHub Actions uses for workload identity federation.

--- a/specs/system/spec-registry.md
+++ b/specs/system/spec-registry.md
@@ -38,21 +38,28 @@ specs:
   - path: system/design-principles.md
     title: Design Principles
     owner: user:jsell
-    requires_approval: true
-    approvers:
-      - user:jsell
+    approval:
+      mode: human_only  # Value judgments require human intent
+      human_approvers:
+        - user:jsell
     gates:
-      - accountability
+      - persona: accountability
 
   - path: system/identity-security.md
     title: Identity & Security
     owner: user:jsell
-    requires_approval: true
-    approvers:
-      - user:jsell
+    approval:
+      mode: human_and_agent
+      human_approvers:
+        - user:jsell
+      agent_approvers:
+        - persona: security
+          min_attestation_level: 3
+        - persona: accountability
     gates:
-      - security
-      - accountability
+      - persona: security
+        min_attestation_level: 3
+      - persona: accountability
 
   - path: system/source-control.md
     title: Source Control
@@ -65,20 +72,33 @@ specs:
   - path: system/supply-chain.md
     title: Supply Chain Security
     owner: user:jsell
+    approval:
+      mode: human_and_agent
+      human_approvers:
+        - user:jsell
+      agent_approvers:
+        - persona: security
+          min_attestation_level: 3
     gates:
-      - security
+      - persona: security
+        min_attestation_level: 3
 
   - path: system/agent-gates.md
     title: Agent Gates & Spec Binding
     owner: user:jsell
     gates:
-      - security
-      - accountability
+      - persona: security
+      - persona: accountability
 
-  # Development specs (how Gyre gets built)
+  # Development specs - agent-only approval is sufficient
+  # for mechanical/structural specs
   - path: development/architecture.md
     title: Architecture & Standards
     owner: user:jsell
+    approval:
+      mode: agent_only
+      agent_approvers:
+        - persona: accountability
 
   - path: development/ralph-loops.md
     title: Ralph Loops
@@ -92,25 +112,28 @@ specs:
   - path: system/trusted-foundry-integration.md
     title: Trusted Foundry (Future)
     owner: user:jsell
-    auto_create_tasks: false  # Reference only, no implementation expected
+    auto_create_tasks: false
 
   # Personas (not implementation contracts)
   - path: personas/ceo.md
     title: CEO Agent Persona
     owner: user:jsell
-    requires_approval: false
+    approval:
+      mode: human_only  # Personas define agent behavior - human must approve
     auto_create_tasks: false
 
   - path: personas/accountability.md
     title: Accountability Agent Persona
     owner: user:jsell
-    requires_approval: false
+    approval:
+      mode: human_only
     auto_create_tasks: false
 
   - path: personas/security.md
     title: Security Agent Persona
     owner: user:jsell
-    requires_approval: false
+    approval:
+      mode: human_only
     auto_create_tasks: false
 ```
 
@@ -121,12 +144,39 @@ specs:
 | `path` | string | required | Relative path from `specs/` |
 | `title` | string | required | Human-readable name |
 | `owner` | string | required | User or team responsible |
-| `requires_approval` | bool | true | Must be approved before code can reference it |
-| `approvers` | string[] | [owner] | Who can approve this spec. Empty = anyone with approval permission |
-| `gates` | string[] | [] | Gate agent personas that review MRs referencing this spec |
-| `auto_create_tasks` | bool | true | Create tasks on spec change (from spec-lifecycle) |
+| `approval.mode` | enum | `human_and_agent` | `human_only`, `agent_only`, or `human_and_agent` |
+| `approval.human_approvers` | string[] | [owner] | Users who can approve |
+| `approval.agent_approvers` | object[] | [] | Agent personas that can approve (see below) |
+| `gates` | object[] | [] | Gate agent configs for MRs referencing this spec (see below) |
+| `auto_create_tasks` | bool | true | Create tasks on spec change |
 | `auto_invalidate_on_change` | bool | true | Invalidate approval when content changes |
-| `superseded_by` | string | null | Path to replacement spec (marks this as deprecated) |
+| `superseded_by` | string | null | Path to replacement spec |
+
+### Agent Approver / Gate Schema
+
+Agent approvers and gates share the same schema:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `persona` | string | required | Persona name (e.g., `security`, `accountability`) |
+| `min_attestation_level` | int | 1 | Minimum attestation level (1=raw, 2=CLI, 3=Gyre-managed) |
+| `stack_hash` | string | null | If set, the agent's stack fingerprint must match exactly |
+
+When `stack_hash` is set, the forge verifies the agent's OIDC token contains a matching `stack_hash` claim. This prevents a weakened persona from producing approvals that satisfy policies written for the original persona.
+
+When `stack_hash` is null, any attested agent running the named persona is accepted. This is more flexible but less strict.
+
+### Approval Modes
+
+| Mode | When to Use | What's Required |
+|---|---|---|
+| `human_only` | Value judgments, business decisions, persona definitions | At least one human from `human_approvers` must approve |
+| `agent_only` | Mechanical/structural checks, spec format validation, code-to-spec alignment | At least one agent from `agent_approvers` must approve (with matching attestation) |
+| `human_and_agent` | Security-sensitive specs, anything where both intent and detail matter | At least one human AND at least one agent must approve |
+
+**Default is `human_and_agent`.** The agent catches what humans miss (did every requirement get addressed?), the human catches what agents miss (is this the right thing to build?).
+
+**`agent_only` is the scaling lever.** If you trust the Accountability agent's stack (pinned, attested, Level 3), and its job is purely mechanical (compare spec to code), requiring a human to rubber-stamp that is ceremony without value. This is the SDLC philosophy: if the need can be engineered away, do it.
 
 ### Manifest Rules
 
@@ -145,10 +195,8 @@ CREATE TABLE spec_registry (
     title           TEXT NOT NULL,
     owner           TEXT NOT NULL,
     current_sha     TEXT NOT NULL,
+    approval_mode   TEXT NOT NULL DEFAULT 'human_and_agent',
     approval_status TEXT NOT NULL DEFAULT 'pending',
-    approved_by     TEXT,
-    approved_at     INTEGER,
-    approval_sig    TEXT,
     linked_tasks    TEXT NOT NULL DEFAULT '[]',
     linked_mrs      TEXT NOT NULL DEFAULT '[]',
     drift_status    TEXT NOT NULL DEFAULT 'unknown',
@@ -156,7 +204,39 @@ CREATE TABLE spec_registry (
     created_at      INTEGER NOT NULL,
     updated_at      INTEGER NOT NULL
 );
+
+CREATE TABLE spec_approvals (
+    id              TEXT PRIMARY KEY,
+    spec_path       TEXT NOT NULL REFERENCES spec_registry(path),
+    spec_sha        TEXT NOT NULL,
+    approver_type   TEXT NOT NULL,  -- 'human' or 'agent'
+    approver_id     TEXT NOT NULL,  -- user:jsell or agent:security-gate-7
+    stack_hash      TEXT,           -- agent stack fingerprint (null for humans)
+    attestation_level INTEGER,     -- 1/2/3 (null for humans)
+    persona         TEXT,           -- agent persona name (null for humans)
+    signature       TEXT,           -- Sigstore signature
+    approved_at     INTEGER NOT NULL,
+    revoked_at      INTEGER,
+    revoked_by      TEXT,
+    revocation_reason TEXT
+);
 ```
+
+### Approval Status Resolution
+
+The ledger's `approval_status` is computed from the `approval_mode` and the approvals in `spec_approvals`:
+
+| Mode | Status = Approved When |
+|---|---|
+| `human_only` | At least one valid human approval exists for `current_sha` |
+| `agent_only` | At least one valid agent approval exists for `current_sha` with matching attestation constraints |
+| `human_and_agent` | At least one valid human AND at least one valid agent approval exist for `current_sha` |
+
+An approval is **valid** when:
+- `spec_sha` matches `current_sha` (not stale)
+- `revoked_at` is null (not revoked)
+- For agents: `attestation_level >= min_attestation_level` from manifest
+- For agents: `stack_hash` matches manifest's required `stack_hash` (if specified)
 
 ### Ledger State Machine
 
@@ -164,7 +244,7 @@ CREATE TABLE spec_registry (
                     push with new content
     APPROVED ---------------------------------> PENDING
         |                                          |
-        |  (no changes)                            |  approval submitted
+        |  (no changes)                            |  all required approvals submitted
         |                                          |
         +--- APPROVED <----------------------------+
                 |
@@ -173,6 +253,8 @@ CREATE TABLE spec_registry (
                 v
             DEPRECATED
 ```
+
+When content changes, ALL existing approvals for the old SHA become stale automatically (the SHA no longer matches). Both human and agent approvals must be re-obtained for the new SHA.
 
 ### Ledger Sync on Push
 


### PR DESCRIPTION
## Summary
Updates two specs:

### spec-registry.md
- Three approval modes: `human_only`, `agent_only`, `human_and_agent`
- Agent approvers with `persona`, `min_attestation_level`, `stack_hash`
- Gates gain same schema (persona + attestation constraints)
- Separate `spec_approvals` table with per-approval attestation metadata
- Approval status computed from mode + matching approvals

### identity-security.md
- `stack_hash`, `persona`, `attestation_level` added as OIDC JWT claims
- Stack identity verified uniformly via token - no separate field needed everywhere

## Test plan
- [ ] Both specs updated
- [ ] No em-dashes
- [ ] OIDC token example includes new claims
- [ ] Manifest example demonstrates all three modes