### PR TITLE
docs(specs): add M19 Container Runtime row to specs/index.md

### DIFF
--- a/specs/index.md
+++ b/specs/index.md
@@ -90,6 +90,7 @@ How Gyre gets built - process and standards for the agent team.
 | M16: Security Hardening | [`milestones/m16-security-hardening.md`](milestones/m16-security-hardening.md) | Release automation endpoint, git argument injection prevention (M16-A), CISO finding resolutions |
 | M17: Integration Testing | [`milestones/m17-integration-testing.md`](milestones/m17-integration-testing.md) | 67 API tests, 21 auth/RBAC tests, 12 git tests, 20 Playwright E2E tests |
 | M18: Agent Identity | [`milestones/m18-agent-identity.md`](milestones/m18-agent-identity.md) | EdDSA JWT agent tokens, OIDC provider, token introspection, JWT revocation, stale-spec detection |
+| M19: Container Runtime | [`milestones/m19-container-runtime.md`](milestones/m19-container-runtime.md) | Container-first agent runtime: Docker/Podman ContainerTarget with security defaults, procfs liveness monitor, workload attestation, SSH compute targets + reverse tunnels |
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

`specs/milestones/m19-container-runtime.md` exists but was missing from the milestone table in `specs/index.md`. The table jumped from M18 to the Open Questions section.

**Added row:**
```
| M19: Container Runtime | milestones/m19-container-runtime.md | Container-first agent runtime: Docker/Podman ContainerTarget with security defaults, procfs liveness monitor, workload attestation, SSH compute targets + reverse tunnels |
```

Companion to PR #223 (README M19 row). Both fix the same omission in different entry points.

## Test plan

- [x] Link to `milestones/m19-container-runtime.md` verified — file exists
- [x] Summary matches the M19 spec motivation and design sections
- [x] Pre-commit passed
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)