### PR TITLE
docs: add M20 UI Accountability milestone row to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ See [AGENTS.md](AGENTS.md) for the full environment variable and API reference.
 | M17: Integration Testing | Done | 67 REST API contract tests, 21 auth/RBAC tests, 12 git smart HTTP tests, 20 Playwright E2E tests |
 | M18: Agent Identity | Done | EdDSA JWT agent tokens, built-in OIDC provider, token introspection, JWT revocation on complete, stale-spec detection |
 | M19: Container Runtime | Done | Docker/Podman ContainerTarget with security defaults, procfs agent monitor, workload attestation, SSH compute targets + reverse tunnels |
+| M20: UI Accountability | Done | 19 frontend findings resolved: admin panels (SIEM/Compute/Network/Spawn Log), Repo Detail Policy/Activity/Gates tabs, MR dependency panel, merge queue DAG view, task detail view, token introspection, spec approvals view |
 
 741 Rust + 95 vitest component + 20 Playwright E2E tests passing (including E2E Ralph loop integration test). Hexagonal architecture enforced mechanically.
 


### PR DESCRIPTION
## Summary

- Adds the M20: UI Accountability milestone row to the README milestone status table
- M20 resolved 19 frontend findings (admin panels, Repo Detail tabs, MR dependency panel, merge queue DAG, task detail view, token introspection, spec approvals)
- M19 was the previous last row; M20 was missing

## Test plan
- [ ] README milestone table now shows M0–M20 as Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)