### PR TITLE
fix(web): fix AdminPanel modal dialogs covered by backdrop (z-index bug)

### DIFF
--- a/web/src/components/AdminPanel.svelte
+++ b/web/src/components/AdminPanel.svelte
@@ -1363,6 +1363,11 @@
   }
 
   .modal {
+    position: fixed;
+    z-index: 101;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     background: var(--color-surface);
     border: 1px solid var(--color-border-strong);
     border-radius: var(--radius-lg);
@@ -1370,6 +1375,8 @@
     min-width: 360px;
     max-width: 480px;
     width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
     box-shadow: var(--shadow-lg);
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

- All modal dialogs in AdminPanel (Kill Agent, Reassign, Add SIEM, Edit SIEM, Add Compute Target, Add Network Peer) were completely unusable — clicking the backdrop closed the dialog, and form fields could not be focused
- Root cause: `.modal-backdrop` has `position: fixed; z-index: 100` but `.modal` (a sibling div) had no `position` property, so it rendered in document flow behind the backdrop
- Fix: add `position: fixed; z-index: 101; top: 50%; left: 50%; transform: translate(-50%, -50%)` to `.modal`, plus `max-height: 90vh; overflow-y: auto` for tall-viewport safety

## Test plan

- [ ] Open Admin Panel → Agents tab → click Kill on any agent → modal appears and is clickable
- [ ] Click Reassign → modal appears with agent selector
- [ ] Open SIEM tab → click Add SIEM Target → form fields are reachable
- [ ] Open Compute tab → click Add Compute Target → form submittable
- [ ] Open Network tab → click Add Peer → form submittable
- [ ] Clicking the backdrop (outside the modal) still closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)