### PR TITLE
fix(server): M21.1 security fixes — revoke ownership, approver type, role check

### DIFF
--- a/crates/gyre-server/src/api/specs.rs
+++ b/crates/gyre-server/src/api/specs.rs
@@ -248,6 +248,18 @@ pub async fn approve_spec(
     let spec_path = encoded_path;
     let now = now_secs();
 
+    // ReadOnly users cannot approve specs (M21.1-C).
+    if auth.roles.contains(&gyre_domain::UserRole::ReadOnly)
+        && !auth.roles.contains(&gyre_domain::UserRole::Admin)
+        && !auth.roles.contains(&gyre_domain::UserRole::Developer)
+        && !auth.roles.contains(&gyre_domain::UserRole::Agent)
+        && auth.agent_id != "system"
+    {
+        return Err(ApiError::Forbidden(
+            "ReadOnly users cannot approve specs".to_string(),
+        ));
+    }
+
     // Validate SHA format (must be 40-char hex).
     if req.sha.len() != 40 || !req.sha.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err(ApiError::InvalidInput(
@@ -265,14 +277,11 @@ pub async fn approve_spec(
         }
     }
 
-    // Determine approver type and identity from auth.
-    // The global token → "system"; agent JWT → agent_id; others → agent_id.
-    let (approver_type, approver_id) = if auth.agent_id == "system" || auth.agent_id.is_empty() {
-        ("human".to_string(), format!("user:{}", auth.agent_id))
-    } else if req.persona.is_some() {
+    // Determine approver type from auth token kind (not request body).
+    // JWT bearer tokens → agent; global token / API key → human.
+    let (approver_type, approver_id) = if auth.jwt_claims.is_some() {
         ("agent".to_string(), format!("agent:{}", auth.agent_id))
     } else {
-        // Global token usage — treat as human.
         ("human".to_string(), format!("user:{}", auth.agent_id))
     };
 
@@ -332,6 +341,24 @@ pub async fn revoke_spec_approval(
             "no active approval for spec '{spec_path}'"
         ))),
         Some(ev) => {
+            // Only the original approver or an Admin can revoke.
+            let is_admin =
+                auth.agent_id == "system" || auth.roles.contains(&gyre_domain::UserRole::Admin);
+            let caller_id = format!(
+                "{}:{}",
+                if auth.jwt_claims.is_some() {
+                    "agent"
+                } else {
+                    "user"
+                },
+                auth.agent_id
+            );
+            if ev.approver_id != caller_id && !is_admin {
+                return Err(ApiError::Forbidden(
+                    "only the original approver or an Admin can revoke".to_string(),
+                ));
+            }
+
             ev.revoked_at = Some(now);
             ev.revoked_by = Some(auth.agent_id.clone());
             ev.revocation_reason = Some(req.reason);


### PR DESCRIPTION
## Summary
CISO findings for spec registry (PR #228):

- **M21.1-A (MEDIUM)**: `revoke_spec_approval` now checks caller is original approver or Admin — returns 403 otherwise
- **M21.1-B (LOW)**: Approver type derived from auth token kind (JWT=agent, global/API key=human), not request body
- **M21.1-C (LOW)**: `approve_spec` rejects ReadOnly users with 403

## Test plan
- Existing spec registry tests pass (approval/revocation flow)
- Non-owner revocation returns 403
- ReadOnly token cannot approve

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>