### PR TITLE
docs: M21.1 security — approve RBAC restriction + approver type derived from token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ cargo build --release -p gyre-server && ./target/release/gyre-server
 | `GET` | `/api/v1/specs/drifted` | Specs with open drift-review tasks — `drift_status: Drifted` (M21.1) |
 | `GET` | `/api/v1/specs/index` | Auto-generated markdown index of all specs in manifest (M21.1) |
 | `GET` | `/api/v1/specs/{path}` | Get single spec ledger entry by URL-encoded path (M21.1) |
-| `POST` | `/api/v1/specs/{path}/approve` | Approve a specific spec version: `{sha}` — path-scoped; transitions ledger Pending → Approved; `sha` must be 40-char hex (M21.1) |
+| `POST` | `/api/v1/specs/{path}/approve` | Approve a specific spec version: `{sha}` — path-scoped; transitions ledger Pending → Approved; `sha` must be 40-char hex; **approver type (`agent`/`human`) derived server-side from token kind** (JWT bearer = agent, global token/API key = human; client must not supply); **Developer+ required** — ReadOnly callers receive 403 (M21.1, M21.1-B, M21.1-C) |
 | `POST` | `/api/v1/specs/{path}/revoke` | Revoke approval for a specific spec: `{reason}` — path-scoped; caller must be original approver or Admin (M21.1) |
 | `GET` | `/api/v1/specs/{path}/history` | Approval event history for a specific spec — list of approval/revocation events with approver, SHA, timestamps, reason (M21.1) |
 | `GET/PUT` | `/api/v1/repos/{id}/push-gates` | Get / set active pre-accept push gates for a repo (built-in: ConventionalCommit, TaskRef, NoEmDash); **PUT requires Admin role** (M13.1) |


### PR DESCRIPTION
## Summary

Documents two CISO security findings from PR #231 that weren't reflected in the `POST /api/v1/specs/{path}/approve` endpoint entry:

- **M21.1-B**: Approver type (`agent` or `human`) is derived server-side from the auth token kind — JWT bearer = agent, global token/API key = human. Client must not supply it. (Matches the existing note on `POST /api/v1/specs/approve` from M12.3.)
- **M21.1-C**: `approve_spec` rejects ReadOnly users with 403. **Developer+ required.**

Note: M21.1-A (revoke ownership check) was already correctly documented in PR #230.

## Test plan
- [ ] CLAUDE.md `POST /api/v1/specs/{path}/approve` row mentions Developer+ requirement and server-side approver type

🤖 Generated with [Claude Code](https://claude.com/claude-code)